### PR TITLE
Untrack personal.muttrc

### DIFF
--- a/muttrc
+++ b/muttrc
@@ -4,7 +4,6 @@ bind index,pager i noop
 bind index,pager g noop
 bind index \Cf noop
 source etc/muttcol
-source personal.muttrc
 source etc/aliases
 set sleep_time = 0
 set sort = 'reverse-date'
@@ -53,3 +52,5 @@ bind index,pager <F4> sidebar-page-down
 bind index,pager \Cp sidebar-prev-new
 bind index,pager \Cn sidebar-next-new
 bind index,pager B sidebar-toggle-visible
+
+source personal.muttrc

--- a/personal.muttrc
+++ b/personal.muttrc
@@ -1,8 +1,0 @@
-# vim: filetype=muttrc
-
-# This file is where the wizard will output
-# information on which file to treat as default
-# and shortcut bindings for jumping from account to account.
-
-# You can edit this manually if you know what you're doing.
-


### PR DESCRIPTION
This commit untracks personal.muttrc and moves the import of
personal.muttrc to the last line of muttrc. I did this for several
reasons:

1. I moved the personal.muttrc import to have the possibility to
   overwrite settings made in muttrc. This makes personalizing mutt
   easier.
2. Since personal.muttrc is currently empty, but gets automatically
   filled with the macros to switch between mail accounts, this will
   always appear as a modified file in `git status`. Also when all mail
   accounts get deleted via mutt-wizzard.sh, personal.muttrc gets
   deleted and therefore might cause inconveniences this way.
3. This makes it virtually impossible to accidentally commit personal
   mutt configurations, which would be pretty easy if personal.muttrc
   stays part of this repo as a tracked file.
4. It makes the repo look and feel nicer.