### PR TITLE
Clear mailboxes list before its assignment.

### DIFF
--- a/autoconf/mutt_profile
+++ b/autoconf/mutt_profile
@@ -16,3 +16,4 @@ set ssl_force_tls = yes
 
 bind index,pager g noop
 bind index gg first-entry
+unmailboxes *


### PR DESCRIPTION
On account change new account's mailboxes are being appended to the old
one's. This commit forces mailboxes list to be cleared before adding new
items to it.