### PR TITLE
Add account name to sidebar head.

### DIFF
--- a/mutt-wizard.sh
+++ b/mutt-wizard.sh
@@ -36,9 +36,20 @@ formatShortcut() { \
 	echo "macro index,pager g$1 \"<change-folder>$data<enter>\" \"Go to $2.\"" >> "$muttdir"accounts/$3.muttrc
 	done ;}
 
+gen_delim() { \
+	delim="="
+	for i in `seq $(( $1 - 1 ))`
+	do
+		delim="$delim-"
+	done
+	echo $delim ;}
+
 detectMailboxes() { \
 	find ~/.mail/$1 -maxdepth 1 -mindepth 1 -type d | sed -e "s/.*\///g;s/^/=/g" > /tmp/$1_boxes
+	sidebar_width=$(sed -n -e '/^set sidebar_width/p' "$muttdir"/muttrc | awk -F'=' '{print $2}')
+	delim=$(gen_delim $sidebar_width)
 	oneline=$(cat /tmp/$1_boxes | tr "\n" " ")
+	oneline="=$1 $delim $oneline"
 	sed -i "/^mailboxes\|^set spoolfile\|^set record\|^set postponed/d" "$muttdir"accounts/$1.muttrc
 	echo mailboxes $oneline >> "$muttdir"accounts/$1.muttrc
 	sed -i "/^macro index,pager g/d" "$muttdir"accounts/$1.muttrc

--- a/muttrc
+++ b/muttrc
@@ -43,7 +43,7 @@ set sidebar_width = 20
 set sidebar_short_path = yes
 set sidebar_next_new_wrap = yes
 set mail_check_stats
-set sidebar_format = '%B%?F? [%F]?%* %?N?%N/?%S'
+set sidebar_format = '%B%?F? [%F]?%* %?N?%N/? %?S?%S?'
 bind index,pager \Ck sidebar-prev
 bind index,pager \Cj sidebar-next
 bind index,pager \Co sidebar-open


### PR DESCRIPTION
When managing multiple accounts it's hard to determine which one you're
currently viewing. This patch makes sidebar look like this:

++++++++++++++++++
luke@lukesmith............|
-------------------------------|
INBOX......................99|
Sent Mail..................... |
Drafts............................|
Trash............................|
Spam............................|
++++++++++++++++++

The only problem with it is the necessity of changing sidebar_format, as with
its current value these 2 excess mailboxes are being appended with 0. That
leads to situation when size of an empty mailbox is being displayed as empty
string instead of 0. I consider it's not a big deal.