### PR TITLE
added option to get rid of XOATH2 authentication failed warnings

### DIFF
--- a/autoconf/offlineimap_profile
+++ b/autoconf/offlineimap_profile
@@ -4,6 +4,7 @@ localrepository = $title-local
 remoterepository = $title-remote
 
 [Repository $title-remote]
+auth_mechanisms = LOGIN
 type = $type
 remoteuser = $login
 sslcacerfile = /etc/ssl/cets/ca-certificates.crt

--- a/credentials/getmuttpass
+++ b/credentials/getmuttpass
@@ -1,4 +1,4 @@
 #!/bin/bash
-pass=$(gpg2 -d -q ~/.config/mutt/credentials/$1.gpg)
+pass=$(gpg2 --decrypt --quiet ~/.config/mutt/credentials/$1.gpg)
 echo set smtp_pass=\"$pass\"
 echo set imap_pass=\"$pass\"


### PR DESCRIPTION
If running offlineimap it will show the following warning message (tested when using GMAIL)...

 XOAUTH2 authentication failed: AUTHENTICATE command error: BAD ['Client aborted AUTHENTICATE command.
<randomstring>']. Data: DIEF2 AUTHENTICATE XOAUTH

... and then continue with the download/sync of emails.
You can get rid of the warning message, when adding auth_mechanisms = LOGIN .offlineimaprc in the <...>-remote section.