### PR TITLE
Changed "port" to "remoteport" in [Repository $title-remote]

### DIFF
--- a/autoconf/offlineimap_profile
+++ b/autoconf/offlineimap_profile
@@ -9,7 +9,7 @@ remoteuser = $login
 sslcacerfile = /etc/ssl/cets/ca-certificates.crt
 remotepasseval = mailpasswd("$title")
 remotehost = $imap
-port = $iport
+remoteport = $iport
 folderfilter = lambda foldername: foldername not in ['[Gmail]/All Mail']
 sslcacertfile = /etc/ssl/certs/ca-certificates.crt
 


### PR DESCRIPTION
configuring offlinemap to get emails from Microsoft Exchange via Davmail I run into a problem, which could be fixed by changing "port" to "remoteport" in the remote-part of the config.
See also here:
https://github.com/OfflineIMAP/offlineimap/blob/master/offlineimap.conf
# This option stands in the [Repository RemoteExample] section.
# Specify the port.  If not specified, use a default port.
#remoteport = 993