### PR TITLE
offline imap quiet option

### DIFF
--- a/etc/mailsync.sh
+++ b/etc/mailsync.sh
@@ -17,7 +17,7 @@ fi
 
 # Get current number of new mail, then begin sync.
 ori=$(find ~/.mail -wholename '*/new/*' | grep -vi "spam\|trash\|junk" | wc -l)
-offlineimap -o
+offlineimap -u quiet -o
 
 # Recount new mail.
 new=$(find ~/.mail -wholename '*/new/*' | grep -vi "spam\|trash\|junk" | wc -l)


### PR DESCRIPTION
Offline imap has a quiet option and it is helpful if the user doesn't want their mail cache flooded with offlineimap's output.