### PR TITLE
Update offlineimap_profile

### DIFF
--- a/autoconf/offlineimap_profile
+++ b/autoconf/offlineimap_profile
@@ -7,7 +7,6 @@ remoterepository = $title-remote
 auth_mechanisms = LOGIN
 type = $type
 remoteuser = $login
-sslcacerfile = /etc/ssl/cets/ca-certificates.crt
 remotepasseval = mailpasswd("$title")
 remotehost = $imap
 remoteport = $iport


### PR DESCRIPTION
Removed "sslcacerfile = /etc/ssl/cets/ca-certificates.crt" on line 10 - it was pointing to non-existant directory "cets" instead of "certs" - this setting is overwritten later with correct path therefore no errors would register.