### PR TITLE
Add mac style notifications to mailsync script on "darwin" operating systems

### DIFF
--- a/etc/mailsync.sh
+++ b/etc/mailsync.sh
@@ -26,3 +26,21 @@ new=$(find ~/.mail -wholename '*/new/*' | grep -vi "spam\|trash\|junk" | wc -l)
 if [ "$new" -gt "$ori" ]; then
 	mpv --quiet ~/.config/mutt/etc/notify.opus
 fi
+
+for account in $(ls ~/.mail)
+do
+        for mailbox in $(ls ~/.mail/$account/)
+        do
+                #List unread messages newer than last mailsync and count them
+                newcount=$(find ~/.mail/$account/$mailbox/new/ -type f -newer ~/.config/mutt/etc/mailsynclastrun 2> /dev/null | wc -l)
+                #Pop a Mac style notification with the count for that mailbox
+                if [ "$(uname)" == "Darwin" -a "$newcount" -gt "0" ]
+                then
+                        osascript -e "display notification \"$newcount in $mailbox\" with title \"Youve got Mail\" subtitle \"Account: $account\""
+                        sleep 2
+                fi
+        done
+done
+
+#Create a touch file that indicates the time of the last run of mailsync
+touch ~/.config/mutt/etc/mailsynclastrun


### PR DESCRIPTION
I kept finding myself wanting to know which of my mailboxes I needed to check when I heard the ding, so I wrote this additional feature. It seems to be working well for me so far. I thought I would see if you may want to consider merging it. This is for my work machine. I plan on adding something similar for my Manjaro i3 box soon too.