### PR TITLE
Fix wrong detection for inbox folder

### DIFF
--- a/mutt-wizard.sh
+++ b/mutt-wizard.sh
@@ -82,13 +82,13 @@ detectMailboxes() { \
 	sed -i "/^mailboxes\|^set spoolfile\|^set record\|^set postponed/d" "$muttdir"accounts/$1.muttrc
 	echo mailboxes $oneline >> "$muttdir"accounts/$1.muttrc
 	sed -i "/^macro index,pager g/d" "$muttdir"accounts/$1.muttrc
-	grep -vi /tmp/$1_boxes -e "trash\|drafts\|sent\|trash\|spam\|junk\|archive\|chat\|old\|new\|gmail\|sms\|call" | sort -n | sed 1q | formatShortcut i inbox $1
+	grep -vi /tmp/$1_boxes -e "trash\|drafts\|sent\|trash\|spam\|junk\|archive\|chat\|old\|new\|gmail\|sms\|call\|delete" | sort -n | sed 1q | formatShortcut i inbox $1
 	grep -i /tmp/$1_boxes -e sent | sed 1q | formatShortcut s sent $1
 	grep -i /tmp/$1_boxes -e draft | sed 1q | formatShortcut d drafts $1
 	grep -i /tmp/$1_boxes -e trash | sed 1q | formatShortcut t trash $1
 	grep -i /tmp/$1_boxes -e spam | sed 1q | formatShortcut S spam $1
 	grep -i /tmp/$1_boxes -e archive | sed 1q | formatShortcut a archive $1
-	spoolfile=$(grep -vi /tmp/$1_boxes -e "trash\|drafts\|sent\|trash\|spam\|ham\|junk\|archive\|chat\|old\|new\|gmail\|sms\|call" | sort -n | sed 1q | sed -e 's/=/+/g')
+	spoolfile=$(grep -vi /tmp/$1_boxes -e "trash\|drafts\|sent\|trash\|spam\|ham\|junk\|archive\|chat\|old\|new\|gmail\|sms\|call\|delete" | sort -n | sed 1q | sed -e 's/=/+/g')
 	record=$(grep -i /tmp/$1_boxes -e sent | sed -e 's/=/+/g' | sed 1q)
 	postponed=$(grep -i /tmp/$1_boxes -e draft | sed -e 's/=/+/g' | sed 1q)
 	trash=$(grep -i /tmp/$1_boxes -e trash | sed -e 's/=/+/g' | sed 1q)

--- a/mutt-wizard.sh
+++ b/mutt-wizard.sh
@@ -82,7 +82,8 @@ detectMailboxes() { \
 	sed -i "/^mailboxes\|^set spoolfile\|^set record\|^set postponed/d" "$muttdir"accounts/$1.muttrc
 	echo mailboxes $oneline >> "$muttdir"accounts/$1.muttrc
 	sed -i "/^macro index,pager g/d" "$muttdir"accounts/$1.muttrc
-	grep -vi /tmp/$1_boxes -e "trash\|drafts\|sent\|trash\|spam\|junk\|archive\|chat\|old\|new\|gmail\|sms\|call\|delete" | sort -n | sed 1q | formatShortcut i inbox $1
+	inbox=$(grep -vi /tmp/$1_boxes -e "trash\|drafts\|sent\|trash\|spam\|junk\|archive\|chat\|old\|new\|gmail\|sms\|call\|delete" | sort -n | sed 1q | sed -e 's/=//g')
+	echo $inbox | formatShortcut i inbox $1
 	grep -i /tmp/$1_boxes -e sent | sed 1q | formatShortcut s sent $1
 	grep -i /tmp/$1_boxes -e draft | sed 1q | formatShortcut d drafts $1
 	grep -i /tmp/$1_boxes -e trash | sed 1q | formatShortcut t trash $1
@@ -92,6 +93,7 @@ detectMailboxes() { \
 	record=$(grep -i /tmp/$1_boxes -e sent | sed -e 's/=/+/g' | sed 1q)
 	postponed=$(grep -i /tmp/$1_boxes -e draft | sed -e 's/=/+/g' | sed 1q)
 	trash=$(grep -i /tmp/$1_boxes -e trash | sed -e 's/=/+/g' | sed 1q)
+	echo "macro index o \"<shell-escape>offlineimap -qf $inbox -a $1<enter>\" \"run offlineimap to sync inbox\"" >> "$muttdir"accounts/$1.muttrc
 	echo "set spoolfile = \"$spoolfile\"" >> "$muttdir"accounts/$1.muttrc
 	echo "set record = \"$record\"" >> "$muttdir"accounts/$1.muttrc
 	echo "set postponed = \"$postponed\"" >> "$muttdir"accounts/$1.muttrc

--- a/muttrc
+++ b/muttrc
@@ -56,6 +56,7 @@ macro index \Cr "T~U<enter><tag-prefix><clear-flag>N<untag-pattern>.<enter>" "ma
 
 #sync email
 macro index O "<shell-escape>offlineimap<enter>" "run offlineimap to sync all mail"
+#this will be overridden by each accout's .muttrc
 macro index o "<shell-escape>offlineimap -qf INBOX<enter>" "run offlineimap to sync inbox"
 
 #copy/move dialogs


### PR DESCRIPTION
- The function detectMailboxes() try explicitly excludes all folder names that are
not inbox, but forget to exclude "Delete" or "Deleted Messages" folder. Outlook
and some other mailboxes have this folder. Without this patch, "Delete" folder
will be set incorrectly as inbox and spoolfile.
- Shortcut 'o' syncing inbox folder should be overridden by each account's muttrc
as each mailbox has its own inbox folder name.