### PR TITLE
fixed mailbox.org smtp server

### DIFF
--- a/autoconf/domains.csv
+++ b/autoconf/domains.csv
@@ -82,7 +82,7 @@ loves.dicksinhisan.us,mail.cock.li,993,mail.cock.li,587
 loves.dicksinmyan.us,mail.cock.li,993,mail.cock.li,587
 lukesmith.xyz,mail.privateemail.com,993,mail.privateemail.com,587
 mail.com,imap.mail.com,995,smtp.mail.com,587
-mailbox.org,imap.mailbox.org,993,smtp.mailbox.org,465
+mailbox.org,imap.mailbox.org,993,smtps.mailbox.org,465
 memeware.net,mail.cock.li,993,mail.cock.li,587
 msn.com,imap-mail.outlook.com,993,smtp-mail.outlook.com,587
 muny.us,mail.muny.us,993,mail.muny.us,465


### PR DESCRIPTION
so I tried to use mailbox.org but upon sending a mail, it was stuck on `connecting to smtp...` I applied this patch and it fixed it :+1: 