### PR TITLE
Added macOS installation notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ accounts.
 
 ### Installation on macOS
 
-You may need to add symbolic links or aliases on macOS, or the account generation logic may fail, or worse.
+You may need to install or symlink additional packages on macOS. Otherwise the generation of configuration files may fail, or worse.
 
 ```
 ln -s /usr/local/bin/gpg /usr/local/bin/gpg2

--- a/README.md
+++ b/README.md
@@ -74,6 +74,17 @@ neomutt and see your mail.  If mutt doesn't immediately work properly run the
 `Redetect mailboxes` option, then open mutt. This may be necessary for some
 accounts.
 
+
+### Installation on macOS
+
+You may need to add symbolic links or aliases on macOS, or the account generation logic may fail, or worse.
+
+```
+ln -s /usr/local/bin/gpg /usr/local/bin/gpg2
+brew install coreutils
+ln -s /usr/local/bin/gshred /usr/local/bin/shred
+```
+
 ### Non-essential dependencies
 
 The automatically deployed configs will look for certain programs for certain


### PR DESCRIPTION
See [related issue](https://github.com/LukeSmithxyz/mutt-wizard/issues/81) for context. 

- Email account creation on macOS may fail due to `gpg2` being aliased as `gpg`. 
- Also, `shred` is not installed on macOS by default, which could lead to password files not being cleaned up in `tmp`. The equivalent is `gshred` which is distributed via `coreutils` using `brew` package manager. 