### PR TITLE
urlscan fix

### DIFF
--- a/muttrc
+++ b/muttrc
@@ -44,8 +44,8 @@ bind index \005 next-undeleted # Mouse wheel
 bind pager \031 previous-line # Mouse wheel
 bind pager \005 next-line # Mouse wheel
 macro index,pager S <sync-mailbox>
-macro index,pager \Cu "|urlscan -r 'echo {} | setsid xargs $BROWSER &'"\n
-macro index,pager ,, "|urlscan -r 'echo {} | setsid xargs $BROWSER &'"\n
+macro index,pager \Cu "|urlscan -r 'setsid $BROWSER {}'"\n
+macro index,pager ,, "|urlscan -r 'setsid $BROWSER {}'"\n
 
 # View attachments properly.
 bind attach <return> view-mailcap


### PR DESCRIPTION
Previous iteration didn't work for urls containg `&` `<` `>` etc due to `xargs` not escaping these characters.
Moreover I was misled by `urlscan` manpage and `xargs` was unnecessary anyhow.