### PR TITLE
ping 1.1.1.1 instead of gateway

### DIFF
--- a/etc/mailsync.sh
+++ b/etc/mailsync.sh
@@ -13,10 +13,10 @@ export DISPLAY=:0.0
 # Settings are different for MacOS (Darwin) systems.
 if [ "$(uname)" = "Darwin" ]
 then
-	ping -q -t 1 -c 1 `ip r | grep -m 1 default | cut -d ' ' -f 3` >/dev/null || exit
+	ping -q -t 1 -c 1 1.1.1.1 > /dev/null || exit
 	notify() { osascript -e "display notification \"$2 in $1\" with title \"You've got Mail\" subtitle \"Account: $account\"" && sleep 2 ;}
 else
-	ping -q -w 1 -c 1 `ip r | grep -m 1 default | cut -d ' ' -f 3` >/dev/null || exit
+	ping -q -W 1 -c 1 1.1.1.1 > /dev/null || exit
 	notify() { mpv --really-quiet ~/.config/mutt/etc/notify.opus & pgrep -x dunst && notify-send -i ~/.config/mutt/etc/email.gif "$2 new mail(s) in \`$1\` account." ;}
 fi
 


### PR DESCRIPTION
Successfully pinging the default gateway doesn't necessarily mean there is an internet connection. Also, on some public networks ICMP is disabled and thus the ping will fail even if there actually is an internet connection.