### PR TITLE
Implement deletion of accounts from .msmtprc

### DIFF
--- a/mutt-wizard.sh
+++ b/mutt-wizard.sh
@@ -127,7 +127,9 @@ removeAccount() { sed -ie "
 	rm "$muttdir"/accounts/$1.muttrc
 	rm "$muttdir"/credentials/$1.gpg
 	rm -rf "$muttdir"/accounts/$1
-	sed -i "/$1.muttrc/d" "$muttdir"/personal.muttrc ;}
+	sed -i "/$1.muttrc/d" "$muttdir"/personal.muttrc 
+	# Delete from the line matching the account name, until the next account or empty line
+	sed -i "/account $1/,/^\(\s*$\|account\)/d" ~/.msmtprc ;}
 
 manual() { \
 	imap=$( dialog --inputbox "Insert the IMAP server for your email provider (excluding the port number)" 10 60 3>&1 1>&2 2>&3 3>&- )


### PR DESCRIPTION
This fixes #122, removing the msmtp configuration for an account in `removeAccount`.

The sed expression deletes from the line matching `account <accountname>`, until the first blank line (or EOF) or the first line starting with "account" in case the accounts are not separated by empty lines.

This may leave a bunch of empty lines, but I suppose that is better than breaking the configuration.