### PR TITLE
Added illinois.edu

### DIFF
--- a/domains.csv
+++ b/domains.csv
@@ -93,6 +93,7 @@ hostgator,gator4171.hostgator.com,993,gator4171.hostgator.com,587
 hotmail.com,imap-mail.outlook.com,993,smtp-mail.outlook.com,587
 hotmail.fr,imap-mail.outlook.com,993,smtp-mail.outlook.com,587
 hushmail.com,imap.hushmail.com,993,smtp.hushmail.com,465
+illinois.edu, imap.gmail.com,993,smtp.gmail.com,465
 iname.com,imap.mail.com,993,smtp.mail.com,587
 insiberia.net,mail.autistici.org,993,smtp.autistici.org,465
 insicuri.net,mail.autistici.org,993,smtp.autistici.org,465


### PR DESCRIPTION
This would cover undergrads. However, grad students use different settings since they are through outlook office365 and not gmail. Do you have any suggestions on how to have both? Both undergrads and grad students get illinois.edu for their email.