### PR TITLE
Mailsync: only pass -a to mbsync when no args

### DIFF
--- a/bin/mailsync
+++ b/bin/mailsync
@@ -18,7 +18,12 @@ echo " 🔃" > /tmp/imapsyncicon_$USER
 pkill -RTMIN+12 i3blocks
 
 # Run mbsync. You can feed this script different settings.
-mbsync -a "$@"
+if [ $# -eq 0 ]; then
+	mbsync -a
+else
+	mbsync "$@"
+fi
+
 rm -f /tmp/imapsyncicon_$USER
 pkill -RTMIN+12 i3blocks
 


### PR DESCRIPTION
Currently, if -a is passed along with `$@`, mailsync will sync all mailboxes even
if only a single channel is passed in with `$@`. This breaks the
semantics of the `o` macro in mutt which should only sync the current
mailbox that is currently being viewed in mutt.

This may break some scripts using mailsync since no channel will be
provided in the case that someone calls `mailsync -V`, for example. At
least it won't introduce any subtle insidious errors.