### PR TITLE
Use correct prefix in muttrc on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,10 @@ install:
 	for shared in share/*; do \
 		cp -f $$shared $(DESTDIR)$(PREFIX)/share/mutt-wizard; \
 	done
+	if [[ "$(OS)" == "Darwin" ]]; then \
+		sed -iba 's/\/usr\//\/usr\/local\//' $(DESTDIR)$(PREFIX)/share/mutt-wizard/mutt-wizard.muttrc; \
+		rm $(DESTDIR)$(PREFIX)/share/mutt-wizard/mutt-wizard.muttrcba; \
+	fi
 	mkdir -p $(DESTDIR)$(MANPREFIX)/man1
 	cp -f mw.1 $(DESTDIR)$(MANPREFIX)/man1/mw.1
 


### PR DESCRIPTION
As stated in PR #193 the `mutt-wizard.muttrc` uses the wrong path prefix for macOS.

This patch replaces `/usr/` with `/usr/local/` in `mutt-wizard.muttrc` when run on Darwin based machines.