### PR TITLE
mailsync improvements and mail preview notifications

### DIFF
--- a/bin/mailsync
+++ b/bin/mailsync
@@ -3,6 +3,8 @@
 
 # Run only if user logged in (prevent cron errors)
 pgrep -cu "$USER" >/dev/null || exit
+# Run only if not already running in other instance
+[ $(pgrep -xf "sh /usr/bin/mailsync" | wc -l) -eq 2 ] || exit
 
 # Checks for internet connection and set notification script.
 ping -q -c 1 1.1.1.1 > /dev/null || exit

--- a/bin/mailsync
+++ b/bin/mailsync
@@ -28,13 +28,9 @@ syncandnotify() {
     if [ "$newcount" -gt "0" ]; then
         notify "$acc" "$newcount" &
         for file in $new; do
-            # Extract subject and sender from mail (room for improvement).
-            subject=$(grep "^Subject: " "$file" | sed 's/Subject: //' | head -n4)
-            from=$(grep "^From: " "$file" | awk '{ $1=""; $NF=""; print $0 }' | tr -d "\"\'\<\>" | sed 's/^ \(.*\) $/\1/')
-            substring="=?"
-            # Some html emails contain weird Subject and/or Sender formatting, in which case the html tag content is used (room for improvement).
-            [ "${subject#*$substring}" != "$subject" ] && subject=$(tr '\n' ' ' < "$file" | sed 's/.*<title>\(.*\)<\/title>.*/\1/')
-            [ "${from#*$substring}" != "$from" ] && from=$(grep ^"From: " "$file" | sed 's/.*<\(.*\)>.*/\1/')
+            # Extract subject and sender from mail.
+            from=$(grep "^From: " "$file" | perl -CS -MEncode -ne 'print decode("MIME-Header", $_)' | awk '{ $1=""; $NF=""; print $0 }' | tr -d "\"\'\<\>" | sed 's/^ \(.*\) $/\1/')
+            subject=$(grep "^Subject: " "$file" | perl -CS -MEncode -ne 'print decode("MIME-Header", $_)' | sed 's/Subject: //')
             notify-send "📧$from:" "$subject" &
         done
     fi

--- a/bin/mailsync
+++ b/bin/mailsync
@@ -30,7 +30,7 @@ syncandnotify() {
         for file in $new; do
             # Extract subject and sender from mail.            
             from=$(awk '/^From: / && ++n ==1,/^\<.*\>:/' "$file" | perl -CS -MEncode -ne 'print decode("MIME-Header", $_)' | awk '{ $1=""; if (NF>=3)$NF=""; print $0 }' | sed 's/^[[:blank:]]*[\"'\''\<]*//;s/[\"'\''\>]*[[:blank:]]*$//')
-            subject=$(awk '/^Subject: / && ++n == 1,/^\<.*\>: /' "$file" | perl -CS -MEncode -ne 'print decode("MIME-Header", $_)' | sed 's/^Subject: //' | sed 's/^{[[:blank:]]*[\"'\''\<]*//;s/[\"'\''\>]*[[:blank:]]*$//')
+            subject=$(awk '/^Subject: / && ++n == 1,/^\<.*\>: / && ++i == 2' "$file" | head -n-1 | perl -CS -MEncode -ne 'print decode("MIME-Header", $_)' | sed 's/^Subject: //' | sed 's/^{[[:blank:]]*[\"'\''\<]*//;s/[\"'\''\>]*[[:blank:]]*$//' | tr -d '\n')
             notify-send "📧$from:" "$subject" &
         done
     fi

--- a/bin/mailsync
+++ b/bin/mailsync
@@ -2,9 +2,9 @@
 # Sync mail and give notification if there is new mail.
 
 # Run only if user logged in (prevent cron errors)
-pgrep -cu "$USER" >/dev/null || exit
+pgrep -u "$USER" >/dev/null || exit
 # Run only if not already running in other instance
-[ $(pgrep -xf "sh /usr/bin/mailsync" | wc -l) -eq 2 ] || exit
+[ "$(pgrep -xf "sh /usr/bin/mailsync.*" | wc -l)" -eq 2 ] || exit
 
 # Checks for internet connection and set notification script.
 ping -q -c 1 1.1.1.1 > /dev/null || exit
@@ -14,31 +14,52 @@ export DISPLAY=:0.0
 
 # Settings are different for MacOS (Darwin) systems.
 if [ "$(uname)" = "Darwin" ]; then
-	notify() { osascript -e "display notification \"$2 in $1\" with title \"You've got Mail\" subtitle \"Account: $account\"" && sleep 2 ;}
+    notify() { osascript -e "display notification \"$2 in $1\" with title \"You've got Mail\" subtitle \"Account: $account\"" && sleep 2 ;}
 else
-	notify() { notify-send "mutt-wizard" "📬 $2 new mail(s) in \`$1\` account." ;}
+    notify() { notify-send "mutt-wizard" "📬 $2 new mail(s) in \`$1\` account." ;}
 fi
 
-echo " 🔃" > /tmp/imapsyncicon_$USER
-pkill -RTMIN+12 i3blocks
+# Check account for new mail. Notify if there is new content.
+syncandnotify() {
+    acc="$(echo "$account" | sed "s/.*\///")"
+    mbsync "$acc"
+    new=$(find "$HOME/.local/share/mail/$acc/INBOX/new/" "$HOME/.local/share/mail/$acc/Inbox/new/" "$HOME/.local/share/mail/$acc/inbox/new/" -type f -newer "$HOME/.config/mutt/.mailsynclastrun" 2> /dev/null)
+    newcount=$(find "$HOME/.local/share/mail/$acc/INBOX/new/" "$HOME/.local/share/mail/$acc/Inbox/new/" "$HOME/.local/share/mail/$acc/inbox/new/" -type f -newer "$HOME/.config/mutt/.mailsynclastrun" 2> /dev/null | wc -l)
+    if [ "$newcount" -gt "0" ]; then
+        notify "$acc" "$newcount" &
+        for file in $new; do
+            # Extract subject and sender from mail (room for improvement).
+            subject=$(grep "^Subject: " "$file" | sed 's/Subject: //' | head -n4)
+            from=$(grep "^From: " "$file" | awk '{ $1=""; $NF=""; print $0 }' | tr -d "\"\'\<\>" | sed 's/^ \(.*\) $/\1/')
+            substring="=?"
+            # Some html emails contain weird Subject and/or Sender formatting, in which case the html tag content is used (room for improvement).
+            [ "${subject#*$substring}" != "$subject" ] && subject=$(tr '\n' ' ' < "$file" | sed 's/.*<title>\(.*\)<\/title>.*/\1/')
+            [ "${from#*$substring}" != "$from" ] && from=$(grep ^"From: " "$file" | sed 's/.*<\(.*\)>.*/\1/')
+            notify-send "📧$from:" "$subject" &
+        done
+    fi
+}
 
-# Run mbsync. You can feed this script different settings.
-if [ $# -eq 0 ]; then
-	mbsync -a
+# Run
+if [ "$#" -eq "0" ]; then
+    accounts="$(ls "$HOME/.local/share/mail")"
 else
-	mbsync "$@"
+    accounts=$*
 fi
 
-rm -f /tmp/imapsyncicon_$USER
-pkill -RTMIN+12 i3blocks
+echo " 🔃" > /tmp/imapsyncicon_"$USER"
+pkill -RTMIN+12 i3blocks >/dev/null 2>&1
 
-# Check all accounts/mailboxes for new mail. Notify if there is new content.
-for account in "$HOME/.local/share/mail/"*
+# Parallelize multiple accounts
+for account in $accounts
 do
-	acc="$(echo "$account" | sed "s/.*\///")"
-	newcount=$(find "$HOME/.local/share/mail/$acc/INBOX/new/" "$HOME/.local/share/mail/$acc/Inbox/new/" "$HOME/.local/share/mail/$acc/inbox/new/" -type f -newer "$HOME/.config/mutt/.mailsynclastrun" 2> /dev/null | wc -l)
-	[ "$newcount" -gt "0" ] && notify "$acc" "$newcount" &
+    syncandnotify &
 done
+
+wait
+rm -f /tmp/imapsyncicon_"$USER"
+pkill -RTMIN+12 i3blocks >/dev/null 2>&1
+
 notmuch new 2>/dev/null
 
 #Create a touch file that indicates the time of the last run of mailsync

--- a/bin/mailsync
+++ b/bin/mailsync
@@ -28,9 +28,9 @@ syncandnotify() {
     if [ "$newcount" -gt "0" ]; then
         notify "$acc" "$newcount" &
         for file in $new; do
-            # Extract subject and sender from mail.
-            from=$(grep "^From: " "$file" | perl -CS -MEncode -ne 'print decode("MIME-Header", $_)' | awk '{ $1=""; if ($NF>=3)$NF=""; print $0 }' | tr -d "\"\'\<\>" | sed 's/^ \(.*\) $/\1/')
-            subject=$(sed -n '/^Subject: /,/^.*:/p' "$file" | perl -CS -MEncode -ne 'print decode("MIME-Header", $_)' | sed 's/^Subject: //' | head -n-1)
+            # Extract subject and sender from mail.            
+            from=$(awk '/^From: / && ++n ==1,/^\<.*\>:/' "$file" | perl -CS -MEncode -ne 'print decode("MIME-Header", $_)' | awk '{ $1=""; if (NF>=3)$NF=""; print $0 }' | sed 's/^[[:blank:]]*[\"'\''\<]*//;s/[\"'\''\>]*[[:blank:]]*$//')
+            subject=$(awk '/^Subject: / && ++n == 1,/^\<.*\>: /' "$file" | perl -CS -MEncode -ne 'print decode("MIME-Header", $_)' | sed 's/^Subject: //' | sed 's/^{[[:blank:]]*[\"'\''\<]*//;s/[\"'\''\>]*[[:blank:]]*$//')
             notify-send "📧$from:" "$subject" &
         done
     fi

--- a/bin/mailsync
+++ b/bin/mailsync
@@ -29,8 +29,8 @@ syncandnotify() {
         notify "$acc" "$newcount" &
         for file in $new; do
             # Extract subject and sender from mail.
-            from=$(grep "^From: " "$file" | perl -CS -MEncode -ne 'print decode("MIME-Header", $_)' | awk '{ $1=""; $NF=""; print $0 }' | tr -d "\"\'\<\>" | sed 's/^ \(.*\) $/\1/')
-            subject=$(grep "^Subject: " "$file" | perl -CS -MEncode -ne 'print decode("MIME-Header", $_)' | sed 's/Subject: //')
+            from=$(grep "^From: " "$file" | perl -CS -MEncode -ne 'print decode("MIME-Header", $_)' | awk '{ $1=""; if ($NF>=3)$NF=""; print $0 }' | tr -d "\"\'\<\>" | sed 's/^ \(.*\) $/\1/')
+            subject=$(sed -n '/^Subject: /,/^.*:/p' "$file" | perl -CS -MEncode -ne 'print decode("MIME-Header", $_)' | sed 's/^Subject: //' | head -n-1)
             notify-send "📧$from:" "$subject" &
         done
     fi

--- a/bin/mailsync
+++ b/bin/mailsync
@@ -27,25 +27,35 @@ syncandnotify() {
     newcount=$(echo "$new" | sed '/^\s*$/d' | wc -l)
     if [ "$newcount" -gt "0" ]; then
         notify "$acc" "$newcount" &
-        for file in $new; do
-            # Extract subject and sender from mail.            
-            from=$(awk '/^From: / && ++n ==1,/^\<.*\>:/' "$file" | perl -CS -MEncode -ne 'print decode("MIME-Header", $_)' | awk '{ $1=""; if (NF>=3)$NF=""; print $0 }' | sed 's/^[[:blank:]]*[\"'\''\<]*//;s/[\"'\''\>]*[[:blank:]]*$//')
-            subject=$(awk '/^Subject: / && ++n == 1,/^\<.*\>: / && ++i == 2' "$file" | head -n-1 | perl -CS -MEncode -ne 'print decode("MIME-Header", $_)' | sed 's/^Subject: //' | sed 's/^{[[:blank:]]*[\"'\''\<]*//;s/[\"'\''\>]*[[:blank:]]*$//' | tr -d '\n')
-            notify-send "📧$from:" "$subject" &
-        done
+        if [ "$preview" = true ]; then
+            for file in $new; do
+                # Extract subject and sender from mail.
+                from=$(awk '/^From: / && ++n ==1,/^\<.*\>:/' "$file" | perl -CS -MEncode -ne 'print decode("MIME-Header", $_)' | awk '{ $1=""; if (NF>=3)$NF=""; print $0 }' | sed 's/^[[:blank:]]*[\"'\''\<]*//;s/[\"'\''\>]*[[:blank:]]*$//')
+                subject=$(awk '/^Subject: / && ++n == 1,/^\<.*\>: / && ++i == 2' "$file" | head -n-1 | perl -CS -MEncode -ne 'print decode("MIME-Header", $_)' | sed 's/^Subject: //' | sed 's/^{[[:blank:]]*[\"'\''\<]*//;s/[\"'\''\>]*[[:blank:]]*$//' | tr -d '\n')
+                notify-send "📧$from:" "$subject" &
+            done
+        fi
     fi
 }
-
-# Sync accounts passed as argument or all.
-if [ "$#" -eq "0" ]; then
-    accounts="$(ls "$HOME/.local/share/mail")"
-else
-    accounts=$*
-fi
 
 echo " 🔃" > /tmp/imapsyncicon_"$USER"
 pkill -RTMIN+12 i3blocks >/dev/null 2>&1
 
+# Parse arguments
+accounts=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -p|--preview)
+            preview=true
+            shift ;;
+        *)
+            accounts="${accounts:+${accounts} }$1"
+            shift ;;
+    esac
+done
+
+# If no accounts are passed sync all accounts
+[ -z "$accounts" ] && accounts="$(ls "$HOME/.local/share/mail")"
 # Parallelize multiple accounts
 for account in $accounts
 do

--- a/bin/mailsync
+++ b/bin/mailsync
@@ -24,7 +24,7 @@ syncandnotify() {
     acc="$(echo "$account" | sed "s/.*\///")"
     mbsync "$acc"
     new=$(find "$HOME/.local/share/mail/$acc/INBOX/new/" "$HOME/.local/share/mail/$acc/Inbox/new/" "$HOME/.local/share/mail/$acc/inbox/new/" -type f -newer "$HOME/.config/mutt/.mailsynclastrun" 2> /dev/null)
-    newcount=$(find "$HOME/.local/share/mail/$acc/INBOX/new/" "$HOME/.local/share/mail/$acc/Inbox/new/" "$HOME/.local/share/mail/$acc/inbox/new/" -type f -newer "$HOME/.config/mutt/.mailsynclastrun" 2> /dev/null | wc -l)
+    newcount=$(echo "$new" | sed '/^\s*$/d' | wc -l)
     if [ "$newcount" -gt "0" ]; then
         notify "$acc" "$newcount" &
         for file in $new; do


### PR DESCRIPTION
This allows mailsync to be called like this `bindsym $mod+e exec --no-startup-id mailsync; exec $term -e neomutt && pkill -RTMIN+12 i3blocks` such that it refreshes your mail when you open mutt without it needlessly syncing if a sync is already running.