### PR TITLE
check if .gpg-id is in the pass store on startup

### DIFF
--- a/bin/mw
+++ b/bin/mw
@@ -1,6 +1,10 @@
 #!/bin/sh
 command -V gpg >/dev/null 2>&1 && GPG="gpg" || GPG="gpg2"
-! "$GPG" --list-secret-keys $(cat "$HOME/.password-store/.gpg-id") >/dev/null 2>&1 && printf "\`pass\` must be installed and initialized to encrypt passwords.\\nBe sure it is installed and run \`pass init <yourgpgemail>\`.\\nIf you don't have a GPG public private key pair, run \`$GPG --full-gen-key\` first.\\n" && exit
+[ -r "$HOME/.password-store/.gpg-id" ] &&
+    "$GPG" --list-secret-keys $(cat "$HOME/.password-store/.gpg-id") >/dev/null 2>&1 || {
+        printf "\`pass\` must be installed and initialized to encrypt passwords.\\nBe sure it is installed and run \`pass init <yourgpgemail>\`.\\nIf you don't have a GPG public private key pair, run \`$GPG --full-gen-key\` first.\\n"
+        exit
+    }
 ! command -v mbsync >/dev/null && printf "\`mbsync\` must be installed to run mutt-wizard.\\n" && exit
 
 if [[ "$OSTYPE" == "darwin"* ]]; then


### PR DESCRIPTION
The current test does not terminate  the script in cases  when the user
already has a private GPG key,  but they'd not initialized the password
store.
This leads to an infinite loop in the `getpass()` function.

The commit fixes https://github.com/LukeSmithxyz/mutt-wizard/issues/204