### PR TITLE
use image resolution to display the image attachments

### DIFF
--- a/bin/muttimage
+++ b/bin/muttimage
@@ -1,5 +1,11 @@
 #!/bin/bash
-height=$(stty  size | awk 'BEGIN {FS = " "} {print $1;}')
-width=$(stty  size | awk 'BEGIN {FS = " "} {print $2;}')
+
+#get image resolution
+resolution=$(identify $1 | awk '{print $3}')
+IFS='x' # x is set as delimiter
+read -ra ADDR <<< "$resolution" 
+width=${ADDR[0]}
+height=${ADDR[1]}
+
 ### Display Image / offset with mutt bar
-echo -e "2;3;\n0;1;210;20;$((width*7-250));$((height*14-100));0;0;0;0;$1\n4;\n3;" |  /usr/lib/w3m/w3mimgdisplay &
+echo -e "2;3;\n0;1;0;42;$((width));$((height));0;0;0;0;$1\n4;\n3;" |  /usr/lib/w3m/w3mimgdisplay &


### PR DESCRIPTION
Existing "muttimage" script does not render the image proportionally since it uses terminal col/row size instead of actual image resolution. This change uses the "identify" command to retrieve image resolution and render the image according to it.  See the attached screenshots before and after.
![2019-05-20-1558326889_screenshot_3840x2160](https://user-images.githubusercontent.com/729723/57997293-c5333b00-7b06-11e9-99d9-9d559ed88aab.jpg)
![2019-05-20-1558335391_screenshot_3840x2160](https://user-images.githubusercontent.com/729723/58001963-f405dd00-7b17-11e9-8b61-26aec342387e.jpg)

