### PR TITLE
modify the `find` call in `mailsync` on Mac

### DIFF
--- a/bin/mailsync
+++ b/bin/mailsync
@@ -34,7 +34,9 @@ pkill -RTMIN+12 i3blocks >/dev/null 2>&1
 for account in "$HOME/.local/share/mail/"*
 do
 	acc="$(echo "$account" | sed "s/.*\///")"
-	newcount=$(find "$HOME/.local/share/mail/$acc/INBOX/new/" "$HOME/.local/share/mail/$acc/Inbox/new/" "$HOME/.local/share/mail/$acc/inbox/new/" -type f -newer "$HOME/.config/mutt/.mailsynclastrun" 2> /dev/null | wc -l)
+	folders="$account/INBOX/new/"
+	[ "$(uname)" != "Darwin" ] && folders="$folders $account/Inbox/new/ $account/inbox/new/"
+	newcount=$(find $folders -type f -newer "$HOME/.config/mutt/.mailsynclastrun" 2>/dev/null | wc -l)
 	[ "$newcount" -gt "0" ] && notify "$acc" "$newcount" &
 done
 notmuch new 2>/dev/null


### PR DESCRIPTION
The MacOS `find` command seems to be case insensitive. So the current
`mailsync` script results in counting each local inbox folder thrice,
resulting in the wrong # of new mails the user is notified about.
The commit implements another `test` command for `$(uname)` to decide
which arguments should be passed to `find`.

_In ref. to :_
https://github.com/LukeSmithxyz/mutt-wizard/issues/157#issuecomment-494132981