### PR TITLE
Use different SMTP server port for onet.pl

### DIFF
--- a/share/domains.csv
+++ b/share/domains.csv
@@ -138,7 +138,7 @@ one.com,imap.one.com,993,send.one.com,465
 onenetbeyond.org,mail.autistici.org,993,smtp.autistici.org,465
 onet.com.pl,imap.poczta.onet.pl,993,smtp.poczta.onet.pl,465
 onet.eu,imap.poczta.onet.pl,993,smtp.poczta.onet.pl,465
-onet.pl,imap.poczta.onet.pl,993,smtp.poczta.onet.pl,465
+onet.pl,imap.poczta.onet.pl,993,smtp.poczta.onet.pl,587
 online.de,imap.1und1.de,993,smtp.1und1.de,465
 op.pl,imap.poczta.onet.pl,993,smtp.poczta.onet.pl,465
 opoczta.pl,imap.poczta.onet.pl,993,smtp.poczta.onet.pl,465


### PR DESCRIPTION
Even though the following official help page says that port 465 should be used, this didn't work for me (msmtp just hang indefinitely).
Instead port 587 seems to work fine, even though I couldn't fine some official document by the e-mail provider mentioning it.
https://pomoc.poczta.onet.pl/baza-wiedzy/adresy-serwerow-potrzebne-do-konfiguracji/

If someone else can confirm that indeed, 587 works for them as well, feel free to merge this PR.