### PR TITLE
Added Carleton University student email domain to domains.csv

### DIFF
--- a/share/domains.csv
+++ b/share/domains.csv
@@ -42,6 +42,8 @@ chemist.com,imap.mail.com,993,smtp.mail.com,587
 chrissx.ga,chrissx.ga,993,chrissx.ga,25
 clerk.com,imap.mail.com,993,smtp.mail.com,587
 clubmember.org,imap.mail.com,993,smtp.mail.com,587
+cmail.carleton.ca,imap-mail.outlook.com,993,smtp-mail.outlook.com,587
+carleton.ca,imap-mail.outlook.com,993,smtp-mail.outlook.com,587
 cocaine.ninja,mail.cock.li,993,mail.cock.li,587
 cock.email,mail.cock.li,993,mail.cock.li,587
 cock.li,mail.cock.li,993,mail.cock.li,587


### PR DESCRIPTION
There are two domains (cmail.carleton.ca and carleton.ca) but they're aliased to each other or something like that.

If you're curious Carleton University is located in Canada's capital, Ottawa. It's known for having a great Aerospace Engineering program. So of course I'm taking Computer Systems Engineering there :P