### PR TITLE
Fix Error: SASL(-7) with isync on macos.

### DIFF
--- a/bin/mw
+++ b/bin/mw
@@ -54,6 +54,7 @@ Host $imap
 Port  $iport
 User $login
 PassCmd \"pass mutt-wizard-$title\"
+AuthMechs LOGIN
 SSLType $ssltype
 CertificateFile $sslcert
 


### PR DESCRIPTION
When I try to setup mutt-wizard on macos lately, I got an issue relate to SASL on isync 
```
Error: SASL(-7): invalid parameter supplied: Parameter Error in /BuildRoot/Library/Caches/com.apple.xbs/Sources/passwordserver_saslplugins/passwordserver_saslplugins-192.30.1/plain_clienttoken.c near line 195
Log-on not successful.
It seems that either you inputted the wrong password or server settings, or there are other requirements for your account out of the control of mutt-wizard
```
I made an effort to solve that problem by adding `AuthMechs LOGIN` to .mbsyncrc
Details can be found [here](https://sourceforge.net/p/isync/mailman/message/35516737/)