### PR TITLE
restore default text color on 'Ctrl-C' exit

### DIFF
--- a/bin/mw
+++ b/bin/mw
@@ -313,6 +313,8 @@ synchronize_flags=true
 gpg_path=$GPG"
 	echo "$nmbasic" > "$NOTMUCH_CONFIG" ;}
 
+trap 'echo -e "\033[0m\n"' INT
+
 case "$1" in
 	ls) list ;;
 	add) asktype && askinfo && tryconnect && finalize || delete ;;


### PR DESCRIPTION
The terminal text color  wasn't reset when the user  aborted the wizard
while being prompted for input.
This resolves https://github.com/LukeSmithxyz/mutt-wizard/issues/223