### PR TITLE
actually terminate the script on Ctrl-C

### DIFF
--- a/bin/mw
+++ b/bin/mw
@@ -316,7 +316,7 @@ synchronize_flags=true
 gpg_path=$GPG"
 	echo "$nmbasic" > "$NOTMUCH_CONFIG" ;}
 
-trap 'echo -e "\033[0m\n"' INT
+trap 'echo -e "\033[0m\n"; exit' STOP INT ABRT KILL
 
 case "$1" in
 	ls) list ;;


### PR DESCRIPTION
In my [PR 224](https://github.com/LukeSmithxyz/mutt-wizard/pull/224), I
introduced a bug.  While I was catching SIGINT with the trap statement,
I did not actually exit the script and returned into the shell.

Fixes https://github.com/LukeSmithxyz/mutt-wizard/issues/234