### PR TITLE
Avoid lags with some email providers while using IMAP

### DIFF
--- a/share/mutt-wizard.muttrc
+++ b/share/mutt-wizard.muttrc
@@ -22,6 +22,7 @@ set forward_format = "Fwd: %s"	# format of subject when forwarding
 set forward_quote		# include message in forwards
 set reverse_name		# reply as whomever it was to
 set include			# include message in replies
+set mail_check=60 # to avoid lags using IMAP with some email providers (yahoo for example)
 auto_view text/html		# automatically show html (mailcap uses w3m)
 auto_view application/pgp-encrypted
 alternative_order text/plain text/enriched text/html


### PR DESCRIPTION
I contacted MUTT irc channel to solve severe lags while navigating mailboxes of certain email providers with IMAP) (the emails were not stored locally). After extensive testing, changing the default value of mail_check from 5 to 60 solved my problem. I propose this change because several other people might encounter the same problem (especially yahoo users)