### PR TITLE
Make mutt-wizard work with passwords containing single quotes

### DIFF
--- a/bin/mw
+++ b/bin/mw
@@ -107,7 +107,7 @@ set folder = \"imaps://$fulladdr@$imap:$iport\"
 set imap_user = \"$login\"
 set header_cache = $cachedir/$title/headers
 set message_cachedir = $cachedir/$title/bodies
-set imap_pass = \`pass mutt-wizard-$title\`
+set imap_pass = \"\`pass mutt-wizard-$title\`\"
 
 set mbox_type = Maildir
 set ssl_starttls = yes


### PR DESCRIPTION
Currently, if you use `mw` with a password that contains single quotes, Mutt will fail to log in. This is because if the value `imap_pass` contains single quotes and is not surrounded by quotes, Mutt removes the single quotes, rendering an incorrect password. To fix this, the value of `imap_pass` needs to be surrounded by double quotes, e.g. ``set imap_pass = "`pass mutt-wizard-gmail`"``.