### PR TITLE
Add history support to notmuch search

### DIFF
--- a/bin/mailsearch
+++ b/bin/mailsearch
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Run notmuch with a search term and clean up the output.
+HFILE=$HOME"/.cache/notmuch_search_hist"
+SEARCH=$HOME"/.cache/notmuch_search_res" 
+if [ ! -e "$HFILE" ]; then
+    touch "$HFILE"
+fi 
+export HISTCONTROL=ignoreboth
+history -r "$HFILE"
+# Uncomment to use the Vi mode in readline:
+# set -o vi
+x="" 
+echo > $SEARCH
+
+
+echo "Enter a search term to find with notmuch:"
+read -e x 
+history -s "$x"
+
+notmuch search --output=messages "$x" > "$SEARCH"
+cat "$SEARCH"               |
+    sed 's/^id:\(.*\)/\1|/' | # remove the initial "id:"
+    sed 's/\+/\\+/'         | # replace "+" with "\+"
+    sed 's/\$/\\\$/'        | # replace "$" with "\$"
+    tr -d "\n"              | # remove newlines
+    sed 's/.$//'            | # remove the last redundant "|"
+    cat  > "$SEARCH"
+
+history -w "$HFILE"

--- a/share/mutt-wizard.muttrc
+++ b/share/mutt-wizard.muttrc
@@ -63,7 +63,7 @@ bind editor <Tab> complete-query
 macro index,pager a "|abook --add-email\n" 'add sender to abook'
 macro index \Cr "T~U<enter><tag-prefix><clear-flag>N<untag-pattern>.<enter>" "mark all messages as read"
 macro index O "<shell-escape>mailsync -Va<enter>" "run offlineimap to sync all mail"
-macro index \Cf "<enter-command>unset wait_key<enter><shell-escape>read -p 'Enter a search term to find with notmuch: ' x; echo \$x >~/.cache/mutt_terms<enter><limit>~i \"\`notmuch search --output=messages \$(cat ~/.cache/mutt_terms) | head -n 600 | perl -le '@a=<>;s/\^id:// for@a;$,=\"|\";print@a' | perl -le '@a=<>; chomp@a; s/\\+/\\\\+/ for@a;print@a' \`\"<enter>" "show only messages matching a notmuch pattern"
+macro index \Cf "<shell-escape>mailsearch<enter><limit>~i \"\`cat ~/.cache/notmuch_search_res\`\"<enter>" "show only messages matching a notmuch pattern"
 macro index A "<limit>all\n" "show all messages (undo limit)"
 
 # Sidebar mappings


### PR DESCRIPTION
- add history support in notmuch search line
- escape "$" in notmuch output
- remove dangling "|" in notmuch output
- handle empty input in notmuch correctly: pass empty string to mutt instead of \<limit\>ing to previous search