### PR TITLE
Fixed national diacritics for adding sender to abook

### DIFF
--- a/share/mutt-wizard.muttrc
+++ b/share/mutt-wizard.muttrc
@@ -60,7 +60,7 @@ bind pager \031 previous-line		# Mouse wheel
 bind pager \005 next-line		# Mouse wheel
 bind editor <Tab> complete-query
 
-macro index,pager a "|abook --add-email\n" 'add sender to abook'
+macro index,pager a "<enter-command>set my_pipe_decode=\$pipe_decode pipe_decode<return><pipe-message>abook --add-email<return><enter-command>set pipe_decode=\$my_pipe_decode; unset my_pipe_decode<return>" "add the sender address to abook"
 macro index \Cr "T~U<enter><tag-prefix><clear-flag>N<untag-pattern>.<enter>" "mark all messages as read"
 macro index O "<shell-escape>mailsync -Va<enter>" "run mbsync to sync all mail"
 macro index \Cf "<enter-command>unset wait_key<enter><shell-escape>read -p 'Enter a search term to find with notmuch: ' x; echo \$x >~/.cache/mutt_terms<enter><limit>~i \"\`notmuch search --output=messages \$(cat ~/.cache/mutt_terms) | head -n 600 | perl -le '@a=<>;s/\^id:// for@a;$,=\"|\";print@a' | perl -le '@a=<>; chomp@a; s/\\+/\\\\+/ for@a;print@a' \`\"<enter>" "show only messages matching a notmuch pattern"


### PR DESCRIPTION
adding senders with special/national characters in their names adds gibberish to your address book
for example
- Karel Křemel <charles@alembiq.net> 
will result in 
Add "=?UTF-8?Q?Karel_K=C5=99emel?= <charles@alembiq.net>" to /home/charles/.abook/addressbook? (y/n)


