### PR TITLE
Fix script removal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,9 @@ install:
 	cp -f mw.1 $(DESTDIR)$(MANPREFIX)/man1/mw.1
 
 uninstall:
-	for script in bin/*; do \
-		rm -f $(DESTDIR)$(PREFIX)/bin/$$script; \
+	for scriptPath in bin/*; do \
+		scriptFile=$$(basename $$scriptPath); \
+		rm -f $(DESTDIR)$(PREFIX)/bin/$$scriptFile; \
 	done
 	rm -rf $(DESTDIR)$(PREFIX)/share/mutt-wizard
 


### PR DESCRIPTION
The `script` variable you were referring to previously is actually the
relative path to a script, for example `bin/mw`.

This fails to remove the scripts, because, obviously, the path is
incorrect (you can test this by just locally installing and uninstalling inside a temp directory).

I'd suggest renaming `script` to `scriptPath` in line 13
and `shared` to `sharedPath` in line 18
(or whatever variable names you prefer that make it clearer)
to avoid confusion in the future.

Signed-off-by: Kipras Melnikovas <kipras@kipras.org>