### PR TITLE
Protonmail Config Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ mutt-wizard is free/libre software, licensed under the GPLv3.
 ## Watch out for these things:
 - Gmail accounts can now create 'App Password' to use with """less secure""" applications. This password is single use (ie. for setup) and will be stored and encrypted locally. Enabling third-party applications requires turning off two-factor authentication and this will circumvent that. You might also need to manually "Enable IMAP" in the settings.
 - Protonmail accounts will require you to set up "Protonmail Bridge" to access PM's IMAP and SMTP servers. Configure that before running mutt-wizard.
+- Protonmail bridge is prone to timing out. Watch out for this while adding an account. If the bridge times out, try again.
 - If you have a university email, or enterprise-hosted email for work, there might be other hurdles or two-factor authentication you have to jump through. Some, for example, will want you to create a separate IMAP password, etc.
  - `isync` is not fully UTF-8 compatible, so non-Latin characters may be garbled (although sync should succeed). `mw` will also not autocreate mailbox shortcuts since it is looking for English mailbox names. I strongly recommend you to set your email language to English on your mail server to avoid these problems.
 

--- a/bin/mw
+++ b/bin/mw
@@ -134,8 +134,20 @@ askinfo() { \
 		printf "\033[0m"
 	done
 	domain="$(echo "$fulladdr" | sed "s/.*@//")"
+  search_query=$domain
+  while : ; do
+    printf "\nIs your email hosted with Protonmail? [yes/no] "
+    read -r is_protonmail
+    case $is_protonmail in
+      [Yy][Ee][Ss]) is_protonmail=true && break;;
+      [Nn][Oo]) is_protonmail=false && break;;
+      *) printf 'Please answer Yes or No'
+    esac; done;
+  if $is_protonmail; then
+    search_query='protonmail.com'
+  fi
 	printf "\\nSearching for \033[32m%s\033[0m in \033[34m\`domains.csv\`\033[0m..." "$domain"
-	serverinfo="$(grep "^$domain" "$muttshare/domains.csv" 2>/dev/null)"
+	serverinfo="$(grep "^$search_query" "$muttshare/domains.csv" 2>/dev/null)"
 	if [ -z "$serverinfo" ]; then
 		printf "Your email domain is not in mutt-wizard's database yet.\\nmutt-wizard will still autoconfigure everything, but you will have to manually type in your service's IMAP and SMTP server information.\\nYou can usually quickly find this by internet searching for it.\\n"
 		printf "Insert the IMAP server for your email provider (excluding the port number)\\n\033[36m\t"

--- a/bin/mw
+++ b/bin/mw
@@ -208,7 +208,7 @@ EOF
 }
 
 protonfinger() { printf "Getting Protonmail bridge fingerprint...\\n"
-	fingerprint="$(msmtp --serverinfo --host=127.0.0.1 --port=1025 --tls --tls-certcheck=off)" || return 1
+  fingerprint="$(msmtp --serverinfo --host=127.0.0.1 --port=1025 --tls --tls-certcheck=off | grep SHA256: | sed 's/^.*: //')"
 	sed -ibu "s/account $title/&\ntls_trust_file\ntls_fingerprint $fingerprint/" "$msmtprc" ; rm -f "$msmtprc"bu
 }
 

--- a/bin/mw
+++ b/bin/mw
@@ -135,17 +135,19 @@ askinfo() { \
 	done
 	domain="$(echo "$fulladdr" | sed "s/.*@//")"
   search_query=$domain
-  while : ; do
-    printf "\nIs your email hosted with Protonmail? [yes/no] "
-    read -r is_protonmail
-    case $is_protonmail in
-      [Yy][Ee][Ss]) is_protonmail=true && break;;
-      [Nn][Oo]) is_protonmail=false && break;;
-      *) printf 'Please answer Yes or No'
-    esac; done;
-  if $is_protonmail; then
-    search_query='protonmail.com'
-  fi
+  case "$domain" in
+    protonmail.com|protonmail.ch|pm.me)
+      search_query='protonmail.com' && break;;
+    *)
+      while : ; do
+        printf "\nIs your email hosted with Protonmail? [yes/no] "
+        read -r is_protonmail
+        case $is_protonmail in
+          [Yy][Ee][Ss]) search_query='protonmail.com' && break;;
+          [Nn][Oo]) break;;
+          *) printf 'Please answer Yes or No'
+        esac; done;
+  esac
 	printf "\\nSearching for \033[32m%s\033[0m in \033[34m\`domains.csv\`\033[0m..." "$domain"
 	serverinfo="$(grep "^$search_query" "$muttshare/domains.csv" 2>/dev/null)"
 	if [ -z "$serverinfo" ]; then


### PR DESCRIPTION
## In this PR
A couple of updates to mw
* `askinfo()` - Refactor Protonmail account checking. If the email address does not belong to protonmail.com/ch or pm.me, ask if it's hosted via Protonmail regardless. This is because Protonmail can host 3rd party email addresses. If the answer is yes, carry on with Protonmail type configuration, otherwise, go through the regular procedure of checking domains.csv
* `protonfinger()` - This function was failing to extract the SHA256 fingerprint from msmpt. Refactored it to use grep & sed to get the fingerprint without failing.
* `README.md` - Protonmail Bridge has a pitfall of timing out during configuration. Add this as something to watch out for.

I've tested it with Protonmail Bridge on my local machine with 2 email addresses. One was @protonmail.com, the other was at my domain (@trevdev.ca). Configuration works out of the box in neomutt.

## Related Issues
https://github.com/LukeSmithxyz/mutt-wizard/issues/312
https://github.com/LukeSmithxyz/mutt-wizard/issues/95
https://github.com/LukeSmithxyz/mutt-wizard/issues/262