### PR TITLE
Pinentry-tty and curses support

### DIFF
--- a/share/mutt-wizard.muttrc
+++ b/share/mutt-wizard.muttrc
@@ -62,7 +62,7 @@ bind editor <Tab> complete-query
 
 macro index,pager a "<enter-command>set my_pipe_decode=\$pipe_decode pipe_decode<return><pipe-message>abook --add-email<return><enter-command>set pipe_decode=\$my_pipe_decode; unset my_pipe_decode<return>" "add the sender address to abook"
 macro index \Cr "T~U<enter><tag-prefix><clear-flag>N<untag-pattern>.<enter>" "mark all messages as read"
-macro index O "<shell-escape>mailsync -Va<enter>" "run mbsync to sync all mail"
+macro index O "<shell-escape>mbsync -a<enter>" "run mbsync to sync all mail"
 macro index \Cf "<enter-command>unset wait_key<enter><shell-escape>read -p 'Enter a search term to find with notmuch: ' x; echo \$x >~/.cache/mutt_terms<enter><limit>~i \"\`notmuch search --output=messages \$(cat ~/.cache/mutt_terms) | head -n 600 | perl -le '@a=<>;s/\^id:// for@a;$,=\"|\";print@a' | perl -le '@a=<>; chomp@a; s/\\+/\\\\+/ for@a;print@a' \`\"<enter>" "show only messages matching a notmuch pattern"
 macro index A "<limit>all\n" "show all messages (undo limit)"
 


### PR DESCRIPTION
I did edit the line 65 and added directly "mbsync -a" instead of "mailsync...". In current state mutt-wizard doesn't work properly in CLI only environment without X started. This is first step to be able atleast mbsync with terminal only pinentry. The problem still remains in sending an email with terminal only pinentry. Temporary solution for is this to activate gpg key before sending an email and send the email before the key times out.