### PR TITLE
Fix Malformed UTF-8 Character in Mailsync fixes #322

### DIFF
--- a/bin/mailsync
+++ b/bin/mailsync
@@ -2,7 +2,8 @@
 # Sync mail and give notification if there is new mail.
 
 export PATH=$PATH:/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-export DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/$(id -u)/bus
+DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/$(id -u)/bus
+export DBUS_SESSION_BUS_ADDRESS
 export DISPLAY=:0.0
 [ -d "$HOME/.local/share/password-store" ] && export PASSWORD_STORE_DIR="$HOME/.local/share/password-store"
 

--- a/bin/mailsync
+++ b/bin/mailsync
@@ -2,8 +2,7 @@
 # Sync mail and give notification if there is new mail.
 
 export PATH=$PATH:/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/$(id -u)/bus
-export DBUS_SESSION_BUS_ADDRESS
+export DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/$(id -u)/bus
 export DISPLAY=:0.0
 [ -d "$HOME/.local/share/password-store" ] && export PASSWORD_STORE_DIR="$HOME/.local/share/password-store"
 

--- a/share/domains.csv
+++ b/share/domains.csv
@@ -60,7 +60,7 @@ counsellor.com,imap.mail.com,993,smtp.mail.com,587
 cryptolab.net,mail.autistici.org,993,smtp.autistici.org,465
 cumallover.me,mail.cock.li,993,mail.cock.li,587
 cyberservices.com,imap.mail.com,993,smtp.mail.com,587
-datentopf.org,imap.migadu.com,993,smtp.migadu.com,587
+datentopf.org,mail.datentopf.org,993,mail.datentopf.org,587
 deliveryman.com,imap.mail.com,993,smtp.mail.com,587
 dicksinhisan.us,mail.cock.li,993,mail.cock.li,587
 dicksinmyan.us,mail.cock.li,993,mail.cock.li,587
@@ -143,7 +143,6 @@ hotmail.rs,outlook.office365.com,993,smtp.office365.com,587
 hotmail.se,outlook.office365.com,993,smtp.office365.com,587
 hotmail.sg,outlook.office365.com,993,smtp.office365.com,587
 hotmail.sk,outlook.office365.com,993,smtp.office365.com,587
-humbug.pw,imap.migadu.com,993,smtp.migadu.com,587
 hushmail.com,imap.hushmail.com,993,smtp.hushmail.com,465
 illinois.edu, imap.gmail.com,993,smtp.gmail.com,465
 iname.com,imap.mail.com,993,smtp.mail.com,587
@@ -214,7 +213,6 @@ protonmail.ch,127.0.0.1,1143,127.0.0.1,1025
 protonmail.com,127.0.0.1,1143,127.0.0.1,1025
 rape.lol,mail.cock.li,993,mail.cock.li,587
 redchan.it,mail.cock.li,993,mail.cock.li,587
-resch.pw,imap.migadu.com,993,smtp.migadu.com,587
 runbox.com,mail.runbox.com,993,mail.runbox.com,587
 rwth-aachen.de,mail.rwth-aachen.de,993,mail.rwth-aachen.de,587
 sapo.pt,imap.sapo.pt,993,smtp.sapo.pt,587

--- a/share/domains.csv
+++ b/share/domains.csv
@@ -60,7 +60,7 @@ counsellor.com,imap.mail.com,993,smtp.mail.com,587
 cryptolab.net,mail.autistici.org,993,smtp.autistici.org,465
 cumallover.me,mail.cock.li,993,mail.cock.li,587
 cyberservices.com,imap.mail.com,993,smtp.mail.com,587
-datentopf.org,mail.datentopf.org,993,mail.datentopf.org,587
+datentopf.org,imap.migadu.com,993,smtp.migadu.com,587
 deliveryman.com,imap.mail.com,993,smtp.mail.com,587
 dicksinhisan.us,mail.cock.li,993,mail.cock.li,587
 dicksinmyan.us,mail.cock.li,993,mail.cock.li,587
@@ -143,6 +143,7 @@ hotmail.rs,outlook.office365.com,993,smtp.office365.com,587
 hotmail.se,outlook.office365.com,993,smtp.office365.com,587
 hotmail.sg,outlook.office365.com,993,smtp.office365.com,587
 hotmail.sk,outlook.office365.com,993,smtp.office365.com,587
+humbug.pw,imap.migadu.com,993,smtp.migadu.com,587
 hushmail.com,imap.hushmail.com,993,smtp.hushmail.com,465
 illinois.edu, imap.gmail.com,993,smtp.gmail.com,465
 iname.com,imap.mail.com,993,smtp.mail.com,587
@@ -213,6 +214,7 @@ protonmail.ch,127.0.0.1,1143,127.0.0.1,1025
 protonmail.com,127.0.0.1,1143,127.0.0.1,1025
 rape.lol,mail.cock.li,993,mail.cock.li,587
 redchan.it,mail.cock.li,993,mail.cock.li,587
+resch.pw,imap.migadu.com,993,smtp.migadu.com,587
 runbox.com,mail.runbox.com,993,mail.runbox.com,587
 rwth-aachen.de,mail.rwth-aachen.de,993,mail.rwth-aachen.de,587
 sapo.pt,imap.sapo.pt,993,smtp.sapo.pt,587


### PR DESCRIPTION
line 5 defined the variable DBUS_SESSION_BUS_ADDRESS before exporting it in the next line
fixes #322