### PR TITLE
Add app name to notify-send invocation

### DIFF
--- a/bin/mailsync
+++ b/bin/mailsync
@@ -20,7 +20,7 @@ command -v notify-send >/dev/null || echo "Note that \`libnotify\` or \`libnotif
 if [ "$(uname)" = "Darwin" ]; then
     notify() { osascript -e "display notification \"$2 in $1\" with title \"You've got Mail\" subtitle \"Account: $account\"" && sleep 2 ;}
 else
-    notify() { notify-send "mutt-wizard" "📬 $2 new mail(s) in \`$1\` account." ;}
+    notify() { notify-send --app-name="mutt-wizard" "mutt-wizard" "📬 $2 new mail(s) in \`$1\` account." ;}
 fi
 
 # Check account for new mail. Notify if there is new content.
@@ -35,7 +35,7 @@ syncandnotify() {
             # Extract subject and sender from mail.
             from=$(awk '/^From: / && ++n ==1,/^\<.*\>:/' "$file" | perl -CS -MEncode -ne 'print decode("MIME-Header", $_)' | awk '{ $1=""; if (NF>=3)$NF=""; print $0 }' | sed 's/^[[:blank:]]*[\"'\''\<]*//;s/[\"'\''\>]*[[:blank:]]*$//')
             subject=$(awk '/^Subject: / && ++n == 1,/^\<.*\>: / && ++i == 2' "$file" | head -n-1 | perl -CS -MEncode -ne 'print decode("MIME-Header", $_)' | sed 's/^Subject: //' | sed 's/^{[[:blank:]]*[\"'\''\<]*//;s/[\"'\''\>]*[[:blank:]]*$//' | tr -d '\n')
-            notify-send "📧$from:" "$subject" &
+            notify-send --app-name="mutt-wizard" "📧$from:" "$subject" &
         done
     fi
 }


### PR DESCRIPTION
This enables users to easily recognize notifications to be able to
modify or style them through notification daemons.