### PR TITLE
add current email to status bar

### DIFF
--- a/bin/mw
+++ b/bin/mw
@@ -86,6 +86,7 @@ set folder = \"$maildir/$title\"
 set header_cache = $cachedir/$title/headers
 set message_cachedir = $cachedir/$title/bodies
 set mbox_type = Maildir
+set status_format="-%r-"$from": %D [Msgs:%?M?%M/?%m%?n? New:%n?%?o? Old:%o?%?d? Del:%d?%?F? Flag:%F?%?t? Tag:%t?%?p? Post:%p?%?b? Inc:%b?%?l? %l?]---(%s/%S)-%>-(%P)---"
 
 bind index,pager gg noop
 bind index,pager g noop
@@ -107,6 +108,7 @@ set imap_user = \"$login\"
 set header_cache = $cachedir/$title/headers
 set message_cachedir = $cachedir/$title/bodies
 set imap_pass = \"\`pass mutt-wizard-$title\`\"
+set status_format="-%r-"$from": %D [Msgs:%?M?%M/?%m%?n? New:%n?%?o? Old:%o?%?d? Del:%d?%?F? Flag:%F?%?t? Tag:%t?%?p? Post:%p?%?b? Inc:%b?%?l? %l?]---(%s/%S)-%>-(%P)---"
 
 set mbox_type = Maildir
 set ssl_starttls = yes


### PR DESCRIPTION
when u have multiple emails in neomutt at the same time, you can sometimes forget which email you're currently viewing, so with this addition youll be able to see.
all i did was add the email to the default status bar configuration

![image](https://user-images.githubusercontent.com/13357949/75126974-6d73c280-568a-11ea-90fe-e73c16b6b591.png)
heres what it looks like (bottom left)