### PR TITLE
Add Mailfence

### DIFF
--- a/share/domains.csv
+++ b/share/domains.csv
@@ -179,6 +179,7 @@ mail.polimi.it,outlook.office365.com,993,smtp.office365.com,587
 mail.ru,imap.mail.ru,993,smtp.mail.ru,465
 mailbox.org,imap.mailbox.org,993,smtp.mailbox.org,587
 mailbox.tu-dresden.de,msx.tu-dresden.de,993,msx.tu-dresden.de,587
+mailfence.com,imap.mailfence.com,993,smtp.mailfence.com,465
 mailo.com,mail.mailo.com,993,mail.mailo.com,465
 memeware.net,mail.cock.li,993,mail.cock.li,587
 metu.edu.tr,imap.metu.edu.tr,993,smtp.metu.edu.tr,465


### PR DESCRIPTION
Mailfence is a nice email provider from Belgium with decent privacy and a nice UI for their webmail that strikes a nice balance between being uncluttered and being usable for power users. Only paying users get IMAP, but an entry account is pretty cheap. It actually has some user-friendly PGP support built in, and you can learn more from their site at mailfence.com or watch The Hated One's video on email providers.