### PR TITLE
Added support for .config/isync/mbsyncrc

### DIFF
--- a/bin/mailsync
+++ b/bin/mailsync
@@ -26,10 +26,18 @@ else
     notify() { notify-send --app-name="mutt-wizard" "mutt-wizard" "📬 $2 new mail(s) in \`$1\` account." ;}
 fi
 
+# Check if configuration is in ~/.config/isync/mbsyncrc. Otherwise use ~/.mbsyncrc
+
+if test -f "$HOME/.config/isync/mbsyncrc" ; then
+    MBSYNC_CONFIG="$HOME/.config/isync/mbsyncrc"
+else
+    MBSYNC_CONFIG="$HOME/.mbsyncrc"
+fi
+
 # Check account for new mail. Notify if there is new content.
 syncandnotify() {
     acc="$(echo "$account" | sed "s/.*\///")"
-    mbsync "$acc"
+    mbsync -c "$MBSYNC_CONFIG" "$acc"
     new=$(find "$HOME/.local/share/mail/$acc/INBOX/new/" "$HOME/.local/share/mail/$acc/Inbox/new/" "$HOME/.local/share/mail/$acc/inbox/new/" -type f -newer "$HOME/.config/mutt/.mailsynclastrun" 2> /dev/null)
     newcount=$(echo "$new" | sed '/^\s*$/d' | wc -l)
     if [ "$newcount" -gt "0" ]; then
@@ -45,7 +53,7 @@ syncandnotify() {
 
 # Sync accounts passed as argument or all.
 if [ "$#" -eq "0" ]; then
-    accounts="$(awk '/^Channel/ {print $2}' "$HOME/.mbsyncrc")"
+    accounts="$(awk '/^Channel/ {print $2}' "$MBSYNC_CONFIG")"
 else
     accounts=$*
 fi


### PR DESCRIPTION
With this slight modification, the mailsync script automagically checks if there is an mbsyncrc file in $HOME/.config/isync/ to comply with the XDG Base Directory Specification, but also give the user a choice of where to place the configuration.

Please merge my pull request, Luke! Its my first one!