### PR TITLE
remove unnecessary prefix setting up msmtp.

### DIFF
--- a/bin/mw
+++ b/bin/mw
@@ -101,7 +101,7 @@ mutt_profile="# vim: filetype=neomuttrc
 # muttrc file for account $title
 set realname = \"$realname\"
 set from = \"$fulladdr\"
-set sendmail = \"$prefix/bin/msmtp -a $title\"
+set sendmail = \"msmtp -a $title\"
 alias me $realname <$fulladdr>
 set folder = \"imaps://$fulladdr@$imap:$iport\"
 set imap_user = \"$login\"


### PR DESCRIPTION
the prefix is not correct at least for Ubuntu distro. Since doc clearly
states the dependencis. We assume msmpt is on the PATH environment.