### PR TITLE
prevent gpg pinentry

### DIFF
--- a/bin/mailsync
+++ b/bin/mailsync
@@ -6,6 +6,7 @@
 pgrep -u "${USER:=$LOGNAME}" >/dev/null || { echo "$USER not logged in; sync will not run."; exit ;}
 # Run only if not already running in other instance
 pgrep -x mbsync >/dev/null && { echo "mbsync is already running." ; exit ;}
+while pgrep -x ${LOCK:-slock} >/dev/null; do sleep 10; done
 
 # Checks for internet connection and set notification script.
 ping -q -c 1 1.1.1.1 > /dev/null || { echo "No internet connection detected."; exit ;}


### PR DESCRIPTION
Assuming a system with pam-gnupgp, a gpg pinentry would ideally be avoided. Currently a pinentry can slip through when `mailsync` runs right before or after the screen is locked.

I propose the use of an environment variable `LOCK` to specify the lock screen program, assuming `slock` when not defined since I believe this is the default in your dotfiles.