### PR TITLE
fix: Support mbsync options passed to mailsync

### DIFF
--- a/bin/mailsync
+++ b/bin/mailsync
@@ -28,7 +28,7 @@ fi
 # Check account for new mail. Notify if there is new content.
 syncandnotify() {
     acc="$(echo "$account" | sed "s/.*\///")"
-    mbsync "$acc"
+    mbsync $opts "$acc"
     new=$(find "$HOME/.local/share/mail/$acc/INBOX/new/" "$HOME/.local/share/mail/$acc/Inbox/new/" "$HOME/.local/share/mail/$acc/inbox/new/" -type f -newer "$HOME/.config/mutt/.mailsynclastrun" 2> /dev/null)
     newcount=$(echo "$new" | sed '/^\s*$/d' | wc -l)
     if [ "$newcount" -gt "0" ]; then
@@ -46,6 +46,9 @@ syncandnotify() {
 if [ "$#" -eq "0" ]; then
     accounts="$(awk '/^Channel/ {print $2}' "$HOME/.mbsyncrc")"
 else
+    for arg in "$@"; do
+        [ "${arg%${arg#?}}" = '-' ] && opts="${opts:+${opts} }${arg}" && shift 1
+    done
     accounts=$*
 fi
 


### PR DESCRIPTION
`mw` creates the [`mailsync` macro `o` with the option flag `-V`](https://github.com/LukeSmithxyz/mutt-wizard/blob/7c980ec6fbc4e51f3fa663a541de4ff5a4f6587f/bin/mw#L96), but [`mailsync` did not support options (it took `-V` as a channel and errors out)](https://github.com/LukeSmithxyz/mutt-wizard/blob/7c980ec6fbc4e51f3fa663a541de4ff5a4f6587f/bin/mailsync#L56-L59). 

This pull request adds basic support for `-abc` and `--ah --be --ce` style options to be passed to `mbsync`, but does not support options that require additional input (i.e. `-c --config /alternative/.mbsyncrc`).