### PR TITLE
fix: Remove AuthMech misspelled option

### DIFF
--- a/bin/mw
+++ b/bin/mw
@@ -50,12 +50,11 @@ $starttlsoff
 "
 mbsync_profile="IMAPStore $title-remote
 Host $imap
-Port  $iport
+Port $iport
 User $login
 PassCmd \"pass mutt-wizard-$title\"
 AuthMechs LOGIN
 SSLType $ssltype
-AuthMech LOGIN
 CertificateFile $sslcert
 
 MaildirStore $title-local


### PR DESCRIPTION
According to man page of `mbsync`, `AuthMechs` is the correct spelling of the option.