### PR TITLE
Fix set_folder for vxempire.xyz

### DIFF
--- a/bin/mw
+++ b/bin/mw
@@ -102,7 +102,7 @@ set realname = \"$realname\"
 set from = \"$fulladdr\"
 set sendmail = \"msmtp -a $title\"
 alias me $realname <$fulladdr>
-set folder = \"imaps://$fulladdr@$imap:$iport\"
+set folder = \"imaps://$login@$imap:$iport\"
 set imap_user = \"$login\"
 set header_cache = $cachedir/$title/headers
 set message_cachedir = $cachedir/$title/bodies

--- a/share/domains.csv
+++ b/share/domains.csv
@@ -308,3 +308,4 @@ ymail.com,imap.mail.yahoo.com,993,smtp.mail.yahoo.com,465
 unilodz.eu,outlook.office365.com,993,smtp.office365.com,587
 ethz.ch,mail.ethz.ch,993,mail.ethz.ch,587
 bocken.org,imap.gmail.com,993,smtp.gmail.com,465
+vxempire.xyz,vxempire.xyz,993,vxempire.xyz,587


### PR DESCRIPTION
Without this commit, mutt wizard creates this with the domain vxempire.xyz:
~~~
# vim: filetype=neomuttrc
# muttrc file for account qorg3
set realname = "qorg2"
set from = "qorg2@vxempire.xyz"
set sendmail = "msmtp -a qorg3"
alias me qorg2 <qorg2@vxempire.xyz>
set folder = "imaps://qorg2@vxempire.xyz@vxempire.xyz:993"
set imap_user = "qorg2"
set header_cache = /home/qorg/.cache/mutt-wizard/qorg3/headers
set message_cachedir = /home/qorg/.cache/mutt-wizard/qorg3/bodies
set imap_pass = "`pass mutt-wizard-qorg3`
~~~
Basically, mutt-wizard is giving the full address to IMAP server, instead of only the IMAP username. With this commit, now it gives this output:

~~~
# vim: filetype=neomuttrc
# muttrc file for account qorg2
set realname = "qorg"
set from = "qorg2@vxempire.xyz"
set sendmail = "msmtp -a qorg2"
alias me qorg <qorg2@vxempire.xyz>
set folder = "imaps://qorg2@vxempire.xyz:993"
set imap_user = "qorg2"
set header_cache = /home/qorg/.cache/mutt-wizard/qorg2/headers
set message_cachedir = /home/qorg/.cache/mutt-wizard/qorg2/bodies
set imap_pass = "`pass mutt-wizard-qorg2`"
~~~

(folder value has changed by the $login variable)

I've tested this with vxempire.xyz and gmail (which needs full address as user), some testers are needed maybe?
