### PR TITLE
mw does not have issues on FreeBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,5 +112,5 @@ mutt-wizard is free/libre software, licensed under the GPLv3.
 
 ## To-do
 
-- Add ~~Mac OS~~/BSD compatibility (the script is confired to work for Mac OS now)
+- Add ~~Mac OS~~/~~BSD~~ compatibility (the script is confired to work for Mac OS and FreeBSD now)
 - ~~Out-of-the-box compatibility with Protonmail Bridge~~ (I believe this is done, but more bug-testing is welcome since I don't have PM)

--- a/bin/mw
+++ b/bin/mw
@@ -7,7 +7,7 @@ command -V gpg >/dev/null 2>&1 && GPG="gpg" || GPG="gpg2"
         printf "\`pass\` must be installed and initialized to encrypt passwords.\\nBe sure it is installed and run \`pass init <yourgpgemail>\`.\\nIf you don't have a GPG public private key pair, run \`%s --full-gen-key\` first.\\n" "$GPG"
         exit
     }
-! command -v mbsync >/dev/null && printf "\`mbsync\` must be installed to run mutt-wizard.\\n" && exit
+! command -v mbsync >/dev/null && printf "\`mbsync (isync package)\` must be installed to run mutt-wizard.\\n" && exit
 
 prefix="/usr/local"
 muttdir="$HOME/.config/mutt"		# Main mutt config location


### PR DESCRIPTION
Also changed ` "\mbsync\ must be installed to run mutt-wizard.\\n"` with `"\mbsync (isync package)\ must be installed to run mutt-wizard.\\n"` because most in distros (And FreeBSD) the mbsync binary is included in the isync package. So users know which package to install