### PR TITLE
fix blank opt flag

### DIFF
--- a/bin/mailsync
+++ b/bin/mailsync
@@ -30,7 +30,7 @@ fi
 # Check account for new mail. Notify if there is new content.
 syncandnotify() {
     acc="$(echo "$account" | sed "s/.*\///")"
-    mbsync "$opts" "$acc"
+    if [ -z "$opts" ]; then mbsync "$acc"; else mbsync "$opts" "$acc"; fi
     new=$(find "$HOME/.local/share/mail/$acc/INBOX/new/" "$HOME/.local/share/mail/$acc/Inbox/new/" "$HOME/.local/share/mail/$acc/inbox/new/" -type f -newer "$HOME/.config/mutt/.mailsynclastrun" 2> /dev/null)
     newcount=$(echo "$new" | sed '/^\s*$/d' | wc -l)
     if [ "$newcount" -gt "0" ]; then


### PR DESCRIPTION
If no options are passed but the accounts are specified then the blank opt flag causes a (harmless) error message from mbsync about an empy channel.