### PR TITLE
fix crontab set

### DIFF
--- a/bin/mw
+++ b/bin/mw
@@ -303,7 +303,7 @@ choosecron() { ! pgrep cron >/dev/null && echo "No cron manager running. Install
 			read -r minnum
 			printf "\033[0m"
 		done
-		(crontab -l; echo "*/$minnum * * * * $(type mailsync | cut -d' ' -f3)") >/dev/null | crontab - &&
+		(crontab -l; echo "*/$minnum * * * * $(type mailsync | cut -d' ' -f3) >/dev/null 2>&1") | crontab - >/dev/null &&
 			echo "Cronjob added. Mail will sync every $minnum minutes. Be sure you have your cron manager running."
 	fi ;}
 


### PR DESCRIPTION
I think a recent change ( #416 ) tried to send output from crontab to dev/null to avoid messages appearing a) when setting the crontab with mw, b) whenever mailsync is run.  However the redirection was for the string concatenation meaning a null string was piped to cron obliterating the crontab (thank goodness for backups). I have put the redirection in the correct location (similar to a few lines above when removing the mailsync line).  I have also redirected all output of the mailsync (both errors and normal messages) to dev null so it should run "silently"