### PR TITLE
fix premature return from askinfo

### DIFF
--- a/bin/mw
+++ b/bin/mw
@@ -148,7 +148,7 @@ askinfo() { \
   search_query=$domain
   case "$domain" in
     protonmail.com|protonmail.ch|pm.me)
-      search_query='protonmail.com' && return 1;;
+      search_query='protonmail.com' ;;
     *)
       while : ; do
         printf "\nIs your email hosted with Protonmail? [yes/no] "


### PR DESCRIPTION
I believe this addresses issue #456 where if you add a protonmail account you get an error.  This is caused by prematurely returning from the case statement that queries whether you have a protonmail account or not.