### PR TITLE
add check for MANPREFIX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,9 @@ OS = $(shell uname -s)
 ifndef PREFIX
   PREFIX = /usr/local
 endif
-MANPREFIX = $(PREFIX)/share/man
+ifndef MANPREFIX
+  MANPREFIX = $(PREFIX)/share/man
+endif
 
 install:
 	mkdir -p $(DESTDIR)$(PREFIX)/bin


### PR DESCRIPTION
This allows adding this package into OpenBSD which stores `man` pages in `/usr/local/man`.