### PR TITLE
fix regex check for email address (needed for OpenBSD)

### DIFF
--- a/bin/mw
+++ b/bin/mw
@@ -14,7 +14,7 @@ muttdir="$HOME/.config/mutt"		# Main mutt config location
 accdir="$muttdir/accounts"		# Directory for account settings
 maildir="$HOME/.local/share/mail"	# Location of mail storage
 namere="^[a-z_][a-z0-9_-]*$"		# Regex to ensure viable username
-emailre=".\+@.\+\\..\+" 		# Regex to confirm valid email address
+emailre=".+@.+\..+" 			# Regex to confirm valid email address
 muttshare="$prefix/share/mutt-wizard"
 mbsyncrc="$HOME/.mbsyncrc"
 mwconfig="$muttshare/mutt-wizard.muttrc"
@@ -139,7 +139,7 @@ askinfo() { \
 	read -r fulladdr
 	keyid=$("$GPG" --list-keys --with-colons "$fulladdr" | awk -F: '/^pub:/ { print $5 }')
 	printf "\033[0m"
-	while ! echo "$fulladdr" | grep "$emailre" >/dev/null; do
+	while ! echo "$fulladdr" | grep -E "$emailre" >/dev/null; do
 		printf "That is not a valid \033[31memail address\033[0m, please retype the desired email.\\n\\nEmail: \033[36m\t"
 		read -r fulladdr
 		printf "\033[0m"


### PR DESCRIPTION
-E option is cross platform and interprets
pattern as regular expression always

