### PR TITLE
Fix mailboxes on macos

### DIFF
--- a/bin/mw
+++ b/bin/mw
@@ -237,7 +237,7 @@ Archive" && return 0
 
 finalize() { echo "$mailboxes" | xargs -I {} mkdir -p "$maildir/$fulladdr/{}/cur" "$maildir/$fulladdr/{}/tmp" "$maildir/$fulladdr/{}/new"
 	sed -ibu "/$MARKER/d" "$accdir/$idnum-$fulladdr.muttrc" ; rm -f "$accdir/$idnum-$fulladdr.muttrcbu"
-	toappend="mailboxes $(echo "$mailboxes" | sed "s/^/\"=/;s/$/\"/" | paste -sd ' ' )"
+	toappend="mailboxes $(echo "$mailboxes" | sed "s/^/\"=/;s/$/\"/" | paste -sd ' ' - )"
 	for x in $mailboxes; do
 		case "$x" in
 			*[Ss][Ee][Nn][Tt]*) setBox record "$x"; formatShortcut s sent "$x" ;;


### PR DESCRIPTION
The BSD version of paste requires `-` to read from STDIN. Without `-`, the "mailboxes" line in ~/.config/accounts/<email address>.muttrc is empty upon adding a new mailbox via `mw -a <email address>`. The Linux version of paste works fine if `-` is added.