### PR TITLE
fix move/copy macros for tagged messages

### DIFF
--- a/bin/mw
+++ b/bin/mw
@@ -218,8 +218,8 @@ getpass() { while : ; do pass rm -f "$pass_prefix$fulladdr" >/dev/null 2>&1
 
 formatShortcut() { toappend="$toappend
 macro index,pager g$1 \"<change-folder>=$3<enter>\" \"go to $2\" $marker
-macro index,pager M$1 \";<save-message>=$3<enter>\" \"move mail to $2\" $marker
-macro index,pager C$1 \";<copy-message>=$3<enter>\" \"copy mail to $2\" $marker" >> "$accdir/$idnum-$fulladdr.muttrc" ;}
+macro index,pager M$1 \"<save-message>=$3<enter>\" \"move mail to $2\" $marker
+macro index,pager C$1 \"<copy-message>=$3<enter>\" \"copy mail to $2\" $marker" >> "$accdir/$idnum-$fulladdr.muttrc" ;}
 
 setBox() { toappend="$toappend
 set $1 = \"+$2\" $marker" ;}


### PR DESCRIPTION
'move/copy to mailbox' macro only worked for single messages, not for multiple (tagged) messages