### PR TITLE
[README] add info and link to stable AUR package

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ cd mutt-wizard
 sudo make install
 ```
 
-A user of Arch-based distros can also install mutt-wizard from the AUR as
-[mutt-wizard-git](https://aur.archlinux.org/packages/mutt-wizard-git/).
+A user of Arch-based distros can also install the current mutt-wizard release from the AUR as
+[mutt-wizard](https://aur.archlinux.org/packages/mutt-wizard/), or the Github master branch, [mutt-wizard-git](https://aur.archlinux.org/packages/mutt-wizard-git/).
 
 ### Optional Dependencies
 


### PR DESCRIPTION
Since version tags/releases have been  introduced lately, Arch users are
now able to choose between a 'stable' and a 'development' package.