### PR TITLE
remove https://lukesmith.xyz/crypto

### DIFF
--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,3 +1,3 @@
 github: lukesmithxyz
-custom: ["https://lukesmith.xyz/donate", "https://paypal.me/lukemsmith", "https://lukesmith.xyz/crypto"]
+custom: ["https://lukesmith.xyz/donate", "https://paypal.me/lukemsmith"]
 patreon: lukesmith


### PR DESCRIPTION
The link 404's, and there is already a crypto section in https://lukesmith.xyz/donate