### PR TITLE
Update mailsync to check XDG_CONFIG_HOME for mutt config dir

### DIFF
--- a/bin/mailsync
+++ b/bin/mailsync
@@ -33,6 +33,8 @@ case "$(readlink -f /sbin/init)" in
 esac
 export GPG_TTY=$TTY
 
+muttconfig="${XDG_CONFIG_HOME:-$HOME/.config}/mutt"
+
 [ -n "$MBSYNCRC" ] && alias mbsync="mbsync -c $MBSYNCRC" || MBSYNCRC="$HOME/.mbsyncrc"
 
 # Settings are different for MacOS (Darwin) systems.
@@ -58,7 +60,7 @@ esac
 syncandnotify() {
     acc="$(echo "$account" | sed "s/.*\///")"
     if [ -z "$opts" ]; then mbsync "$acc"; else mbsync "$opts" "$acc"; fi
-    new=$(find "$HOME/.local/share/mail/$acc/INBOX/new/" "$HOME/.local/share/mail/$acc/Inbox/new/" "$HOME/.local/share/mail/$acc/inbox/new/" -type f -newer "$HOME/.config/mutt/.mailsynclastrun" 2> /dev/null)
+    new=$(find "$HOME/.local/share/mail/$acc/INBOX/new/" "$HOME/.local/share/mail/$acc/Inbox/new/" "$HOME/.local/share/mail/$acc/inbox/new/" -type f -newer "$muttconfig/.mailsynclastrun" 2> /dev/null)
     newcount=$(echo "$new" | sed '/^\s*$/d' | wc -l)
     if [ "$newcount" -gt "0" ]; then
 	notify "$acc" "$newcount" &
@@ -91,4 +93,4 @@ wait
 notmuch new 2>/dev/null
 
 #Create a touch file that indicates the time of the last run of mailsync
-touch "$HOME/.config/mutt/.mailsynclastrun"
+touch "$muttconfig/.mailsynclastrun"


### PR DESCRIPTION
Had to update my mailsync file with this since I don't use `$HOME/.config`. I know there have been similar issues/PRs around using XDG vars, but I'm not sure this case was covered + if it was, it was among a bunch of other changes.

I did some research to make sure this syntax/approach is 'portable' (POSIX-compliant), but I'm never 100% sure with these things.