### PR TITLE
:bug: Fix ProtonMail log-on failure when adding a new account

### DIFF
--- a/bin/mw
+++ b/bin/mw
@@ -351,6 +351,7 @@ while getopts "fplhodTYD:y:i:I:s:S:u:a:n:x:m:t:" o; do case "${o}" in
 	t) setact toggle || exit 1 ; cronmin="$OPTARG" ;;
 	T) setact toggle || exit 1 ;;
 	p) echo "NOTE: Protonmail users must install and configure Protonmail Bridge first for the first sync to work."
+		protocol="imap"
 		imap="127.0.0.1"
 		iport="1143"
 		smtp="127.0.0.1"

--- a/bin/mw
+++ b/bin/mw
@@ -236,7 +236,7 @@ Junk
 Trash
 Sent
 Archive" && return 0
-	info="$(curl --location-trusted -s -m 5 --user "$login:$(pass $pass_prefix$fulladdr)" --url "${protocol:-imaps}://$imap")"
+	info="$(curl --location-trusted -s -m 5 --user "$login:$(pass $pass_prefix$fulladdr)" --url "${protocol:-imaps}://$imap:${iport:-993}")"
 	[ -z "$info" ] && echo "Log-on not successful." && return 1
 	mailboxes="$(echo "$info" | sed "s/.*\" //;s/\"//g" | tr -d '')"
 }


### PR DESCRIPTION
# What

Trying to add a ProtonMail account would always result in a `Log-on not successful.` message when issuing:
```
mw -a john.doe@protonmail.com -p
```
See references below.

# Why

Recently the log-on check got updated to use `curl`. This works in most cases as `imap`(`s`) servers use default ports (E.g. `993`).
However, the ProtonMail bridge uses port 1143 and without any TLS.

This means we have to supply the `curl` command with protocol `imap` (read: not `imaps`) and port `1143`.

# How

There was already a `protocol` variable in place, but it was never set. In commit 79bb043 we set the protocol to `imap` when the ProtonMail flag (-p) is set.

We also added the `iport` variable to the `curl` command, defaulting it to `993` when not set. In commit 5920ca4 we add the port to the `curl` command. 

# Testing

I have tested adding a new ProtonMail account on this branch. This succeeded. 
I have tested adding a new Gmail account on this branch. This also succeeded.

If you could find any potential issues introduced by this branch/pull request, please let me know.

# References

- https://github.com/LukeSmithxyz/mutt-wizard/issues/622
- https://github.com/LukeSmithxyz/mutt-wizard/issues/608
