### PR TITLE
Fix: `macro index o` overlapping with next account

### DIFF
--- a/bin/mw
+++ b/bin/mw
@@ -122,6 +122,7 @@ bind index,pager g noop
 bind index,pager M noop
 bind index,pager C noop
 bind index gg first-entry
+unmacro index o
 unmailboxes *
 "
 fi


### PR DESCRIPTION
When the transition is made from an offline-profile to an online-profile, there is still someone else's macro:
`macro index o ... mw -y ...` - side effects...

Variables, macros, and so on must be taken-into-account **symmetrically** with any of the `mutt-wizard`'s profiles.

Similar: #596