### PR TITLE
hardcode ZDOTDIR to ${XDG_CONFIG_HOME:-$HOME/.config}/zsh, if it exists.

### DIFF
--- a/bin/mailsync
+++ b/bin/mailsync
@@ -20,6 +20,7 @@ pgrep -x mbsync >/dev/null && { echo "mbsync is already running." ; exit ;}
 # archive, notmuch and the GPG home.  This is done by searching common profile
 # files for variable assignments. This is ugly, but there are few options that
 # will work on the maximum number of machines.
+[ -d "${XDG_CONFIG_HOME:-$HOME/.config}/zsh" ] && ZDOTDIR="${XDG_CONFIG_HOME:-$HOME/.config}/zsh"
 eval "$(grep -h -- \
 	"^\s*\(export \)\?\(MBSYNCRC\|PASSWORD_STORE_DIR\|NOTMUCH_CONFIG\|GNUPGHOME\)=" \
 	"$HOME/.profile" "$HOME/.bash_profile" "${ZDOTDIR:-$HOME}/.zprofile" "$HOME/.bashrc" "${ZDOTDIR:-$HOME}/.zshrc" "$HOME/.pam_environment" 2>/dev/null)"


### PR DESCRIPTION
This way, even if `ZDOTDIR` was something different, the path in the title would not be a directory, so the variable would not be overwritten.