### PR TITLE
Fix duplicate mailsync notifications

### DIFF
--- a/bin/mailsync
+++ b/bin/mailsync
@@ -44,7 +44,7 @@ case "$(uname)" in
 		messageinfo() { osascript -e "display notification with title \"📧 $from\" subtitle \"$subject\"" ;}
 		;;
 	*)
-		displays="$(pgrep -a Xorg | grep -wo "[0-9]*:[0-9]\+")"
+		displays="$(pgrep -a Xorg | grep -wo "[0-9]*:[0-9]\+" | uniq)"
 	    	notify() { for x in $displays; do
 				export DISPLAY=$x
 				notify-send --app-name="mutt-wizard" "mutt-wizard" "📬 $2 new mail(s) in \`$1\` account."


### PR DESCRIPTION
mailsync was giving me duplicate notifications because it would detect the same display twice. I manually ran the command used to get the displays, and found the following:

```sh
$ pgrep -a Xorg
387 /usr/lib/Xorg :0 -seat seat0 -auth /run/lightdm/root/:0 -nolisten tcp vt7 -novtswitch

$ pgrep -a Xorg | grep -wo "[0-9]*:[0-9]\+"
:0
:0
```

To fix this, I just piped the output into uniq:

```sh
$ pgrep -a Xorg | grep -wo "[0-9]*:[0-9]\+" | uniq
:0
```