### PR TITLE
Fix notifications on Wayland-based environments

### DIFF
--- a/bin/mailsync
+++ b/bin/mailsync
@@ -39,7 +39,7 @@ case "$(uname)" in
 		messageinfo() { osascript -e "display notification with title \"📧 $from\" subtitle \"$subject\"" ;}
 		;;
 	*)
-		displays="$(pgrep -a Xorg | grep -wo "[0-9]*:[0-9]\+" | sort -u)"
+		displays="$(pgrep -a X\(org\|wayland\) | grep -wo "[0-9]*:[0-9]\+" | sort -u)"
 	    	notify() { for x in $displays; do
 				export DISPLAY=$x
 				notify-send --app-name="mutt-wizard" "mutt-wizard" "📬 $2 new mail(s) in \`$1\` account."


### PR DESCRIPTION
Notifications does not work on [Wayland](https://wayland.freedesktop.org/). I propose to adjust the `pgrep` command to match both `Xorg` and [`Xwayland`](https://wayland.freedesktop.org/xserver.html) environments.