### PR TITLE
setup some environment vars for the cron job

### DIFF
--- a/bin/mw
+++ b/bin/mw
@@ -224,7 +224,8 @@ getboxes() { if [ -n "${force+x}" ] ; then
 	else
 		info="$(curl --location-trusted -s -m 5 --user "$login:$(pass "$fulladdr")" --url "${protocol:-imaps}://$imap:${iport:-993}")"
 		[ -z "$info" ] && echo "Log-on not successful." && return 1
-		mailboxes="$(echo "$info" | grep -v HasChildren | sed "s/.*\" //;s/\"//g" | tr -d '')"
+		mailboxes="$(echo "$info" | grep -v HasChildren | sed "s/.*\" //;s/\"//g" | tr -d '
+')"
 	fi
 	[ "$type" = "pop" ] && mailboxes="INBOX"
 	getaccounts; for x in $(seq 1 9); do echo "$accounts" | grep -q "^$x:" || { export idnum="$x"; break ;}; done
@@ -275,6 +276,7 @@ togglecron() { cron="$(mktemp)"
 	else
 		echo "Adding automatic mailsync every ${cronmin:-10} minutes..."
 		cat <<EOF >>"$cron"
+# mailsync
 MBSYNCRC=${MBSYNCRC:-$HOME/.mbsynrc}
 NOTMUCH_CONFIG=${NOTMUCH_CONFIG:-$HOME/.notmuch-config}
 GNUPGHOME=${GNUPGHOME:-$HOME/.gnupg}

--- a/bin/mw
+++ b/bin/mw
@@ -271,10 +271,16 @@ togglecron() { cron="$(mktemp)"
 	crontab -l > "$cron"
 	if grep -q mailsync "$cron"; then
 		echo "Removing automatic mailsync..."
-		sed -ibu /mailsync/d "$cron"; rm -f "$cron"bu
+	    sed -ibu '/^# mailsync/,/^.*mailsync$/d' "$cron"; rm -f "$cron"bu
 	else
 		echo "Adding automatic mailsync every ${cronmin:-10} minutes..."
-		echo "*/${cronmin-10} * * * * $prefix/bin/mailsync" >> "$cron"
+		cat <<EOF >>"$cron"
+MBSYNCRC=${MBSYNCRC:-$HOME/.mbsynrc}
+NOTMUCH_CONFIG=${NOTMUCH_CONFIG:-$HOME/.notmuch-config}
+GNUPGHOME=${GNUPGHOME:-$HOME/.gnupg}
+PASSWORD_STORE_DIR=${PASSWORD_STORE_DIR:-$HOME/.password-store}
+*/${cronmin-10} * * * * $prefix/bin/mailsync
+EOF
 	fi &&
 	crontab "$cron"; rm -f "$cron" ;}
 


### PR DESCRIPTION
Some tickets suggest that the mailsync process doesn't have all environ-
ment variables set which are needed. For example:

https://github.com/LukeSmithxyz/mutt-wizard/issues/678
The error messages indicate that for mailsync, `XDG_DATA_HOME` is empty/
unset and hence it cannot resolve the user's gnupg folder.

This commit defines  those variables via the crontab,  which I think are
the relevant ones. Not sure though if these are all we need or if I for-
got some.

Please note, the cronjob itself is still untested because I have no cron
daemon installed on my box. The togglecron function _does_ work properly
though.