### PR TITLE
Fixed mbsync deprecation

### DIFF
--- a/bin/mw
+++ b/bin/mw
@@ -61,8 +61,8 @@ Inbox ${XDG_DATA_HOME:-$HOME/.local/share}/mail/$fulladdr/${inbox:-INBOX}
 
 Channel $fulladdr
 Expunge Both
-Master :$fulladdr-remote:
-Slave :$fulladdr-local:
+Far :$fulladdr-remote:
+Near :$fulladdr-local:
 Patterns * !\"[Gmail]/All Mail\"
 Create Both
 SyncState *


### PR DESCRIPTION
It's deprecated to use `Master` and `Slave`. You also get this message, if you try to get your mails with mbsync. This should fix it.