### PR TITLE
mailsync now uses Far/Near to mean Master/Slave

### DIFF
--- a/bin/mw
+++ b/bin/mw
@@ -61,8 +61,8 @@ Inbox ${XDG_DATA_HOME:-$HOME/.local/share}/mail/$fulladdr/${inbox:-INBOX}
 
 Channel $fulladdr
 Expunge Both
-Master :$fulladdr-remote:
-Slave :$fulladdr-local:
+Far :$fulladdr-remote:
+Near :$fulladdr-local:
 Patterns * !\"[Gmail]/All Mail\"
 Create Both
 SyncState *


### PR DESCRIPTION
Whenever you update mail with `mw -Y`, mailsync now warns that the
Master/Slave commands in the `.mbsyncrc` file were deprecated in
favor of the Far/Near terminology. This PR removes this annoyance
and helps future-proof this project.
