### PR TITLE
update domain list

### DIFF
--- a/share/domains.csv
+++ b/share/domains.csv
@@ -156,6 +156,7 @@ loves.dicksinhisan.us,mail.cock.li,993,mail.cock.li,587
 loves.dicksinmyan.us,mail.cock.li,993,mail.cock.li,587
 lukesmith.xyz,mail.lukesmith.xyz,993,mail.lukesmith.xyz,587
 luther.edu,imap.gmail.com,993,smtp.gmail.com,587
+mac.com,imap.mail.me.com,993,smtp.mail.me.com,587
 mail.com,imap.mail.com,993,smtp.mail.com,587
 mail.de,imap.mail.de,993,smtp.mail.de,465
 mail.mcgill.ca,outlook.office365.com,993,smtp.office365.com,587
@@ -167,6 +168,7 @@ mailbox.tu-dresden.de,msx.tu-dresden.de,993,msx.tu-dresden.de,587
 mailfence.com,imap.mailfence.com,993,smtp.mailfence.com,465
 mailo.com,mail.mailo.com,993,mail.mailo.com,465
 marquette.edu,outlook.office365.com,993,smtp.office365.com,587
+me.com,imap.mail.me.com,993,smtp.mail.me.com,587
 memeware.net,mail.cock.li,993,mail.cock.li,587
 metu.edu.tr,imap.metu.edu.tr,993,smtp.metu.edu.tr,465
 mit.edu,imap.exchange.mit.edu,993,outgoing.mit.edu,465
@@ -276,6 +278,7 @@ ua.pt,outlook.office365.com,993,mail.ua.pt,25
 uach.mx,imap.gmail.com,993,smtp.gmail.com,587
 ucdavis.edu,imap.gmail.com,993,smtp.gmail.com,587
 ucsb.edu,imap.gmail.com,993,smtp.gmail.com,587
+ucsc.edu,imap.gmail.com,993,smtp.gmail.com,587
 uni.strath.ac.uk,outlook.office365.com,993,smtp.office365.com,587
 uni-duesseldorf.de,mail.hhu.de,993,mail.hhu.de,465
 uni-jena.de,imap.uni-jena.de,993,smtp.uni-jena.de,587


### PR DESCRIPTION
add mac alternative domains
(@mac.com/@me.com)
these are legacy domains that
mac used to use which have been
merged into icloud

for more info see:

https://support.apple.com/en-us/HT201771
https://getmailspring.com/setup/access-mac-com-via-imap-smtp

also add ucsc.edu, which like the other uc's uses
google