### PR TITLE
fix deprecated Master/Slave naming

### DIFF
--- a/bin/mw
+++ b/bin/mw
@@ -61,8 +61,8 @@ Inbox ${XDG_DATA_HOME:-$HOME/.local/share}/mail/$fulladdr/${inbox:-INBOX}
 
 Channel $fulladdr
 Expunge Both
-Master :$fulladdr-remote:
-Slave :$fulladdr-local:
+Far :$fulladdr-remote:
+Near :$fulladdr-local:
 Patterns * !\"[Gmail]/All Mail\"
 Create Both
 SyncState *


### PR DESCRIPTION
When syncing mail with command "mbsync -a" It is saying that Master/Slave naming is deprecated in .mbsyncrc, so I did a little fix and changed it to Far/Near instead.