### PR TITLE
password store with multiple private keys fix

### DIFF
--- a/bin/mw
+++ b/bin/mw
@@ -18,8 +18,7 @@ done || { echo "CA Certificate not found. Please install one or link it to /etc/
 
 checkbasics() { command -V gpg >/dev/null 2>&1 && GPG="gpg" || GPG="gpg2"
 	PASSWORD_STORE_DIR="${PASSWORD_STORE_DIR:-$HOME/.password-store}"
-	[ -r "$PASSWORD_STORE_DIR/.gpg-id" ] &&
-	"$GPG" --list-secret-keys "$(cat "$PASSWORD_STORE_DIR/.gpg-id")" >/dev/null 2>&1 || {
+	[ -r "$PASSWORD_STORE_DIR/.gpg-id" ] || {
 	echo "First run \`pass init <yourgpgemail>\` to set up a password archive."
 	echo "(If you don't already have a GPG key pair, first run \`$GPG --full-generate-key\`.)"
        	exit 1 ;} ;}
@@ -204,7 +203,7 @@ askinfo() { \
 }
 
 createpass() { echo "$password" > "$PASSWORD_STORE_DIR/$fulladdr"
-	"$GPG" -qer "$(cat "$PASSWORD_STORE_DIR/.gpg-id")" "$PASSWORD_STORE_DIR/$fulladdr"
+  "$GPG" -qe $(printf -- " -r %s" $(cat "$PASSWORD_STORE_DIR/.gpg-id")) "$PASSWORD_STORE_DIR/$fulladdr"
 	rm -f "$PASSWORD_STORE_DIR/$fulladdr" ;}
 
 getpass() { while : ; do pass rm -f "$fulladdr" >/dev/null 2>&1


### PR DESCRIPTION
I ran into a problem, since my pass password store is encrypted using 2 or more private keys, as with the pass command: `pass init gpg-id...`
The `.gpg-id` file is into a format on multiple lines that the script does not recognize such as:
```
gpg-id1
gpg-id2
...
```
This pull request fixes the problem for me, and makes it so that the generated password will be encrypted using both keys. But i removed some of the logic that verifies the contents of `.gpg-id`, since we could chose to have the script do several things, i.e. 
-verify that all ids are valid and associated to locally stored private keys
-verify that all ids are valid and at least 1 of them has an associated locally stored private key
-verify that all ids are valid regardless of private keys being stored locally