### PR TITLE
Add option to get notifications for non-standard mailboxes

### DIFF
--- a/bin/mailsync
+++ b/bin/mailsync
@@ -57,7 +57,8 @@ esac
 syncandnotify() {
     acc="$(echo "$account" | sed "s/.*\///")"
     if [ -z "$opts" ]; then mbsync "$acc"; else mbsync "$opts" "$acc"; fi
-    new=$(find "$HOME/.local/share/mail/$acc/INBOX/new/" "$HOME/.local/share/mail/$acc/Inbox/new/" "$HOME/.local/share/mail/$acc/inbox/new/" -type f -newer "${XDG_CONFIG_HOME:-$HOME/.config}/mutt/.mailsynclastrun" 2> /dev/null)
+    boxes="INBOX|Inbox|inbox$(sed -E 's/^(.+)/\|\1/' "${XDG_CONFIG_HOME:-$HOME/.config}/mutt/notification_inboxes"  2> /dev/null | tr -d '\n')"
+    new=$(find "$HOME/.local/share/mail/$acc" -regextype posix-egrep -regex ".*($boxes)/new.*" -type f -newer "${XDG_CONFIG_HOME:-$HOME/.config}/mutt/.mailsynclastrun" 2> /dev/null)
     newcount=$(echo "$new" | sed '/^\s*$/d' | wc -l)
     case 1 in
 	$((newcount > 5)) ) notify "$acc" "$newcount" ;;


### PR DESCRIPTION
This adds the option to add mailboxes to a `notification_inboxes` file in the mutt config folder (each name has to be in its own line). When mailsync checks for new mails it will also include those mailboxes to send notifications. When the file doesn't exist or is empty the script works just as before.
My email provider for example puts new mail in a mailbox named `Unbekannt` (German for unknown). The usual `INBOX` mailbox is reserved for known contacts only. And I obviously want to get notifications for mails from strangers that aren't spam.
I think this might be useful to other people that use such email providers.