### PR TITLE
Set hostname variable

### DIFF
--- a/bin/mw
+++ b/bin/mw
@@ -91,6 +91,7 @@ set folder = \"$folder\"
 set header_cache = $cachedir/$fulladdr/headers
 set message_cachedir = $cachedir/$fulladdr/bodies
 set mbox_type = Maildir
+set hostname = \"$hostname\"
 $extra
 
 bind index,pager gg noop
@@ -193,6 +194,7 @@ askinfo() { \
 		read -r smtp
 	[ "$sport" = 465 ] && tlsline="tls_starttls off"
 	[ -z "$realname" ] && realname="${fulladdr%%@*}"
+	hostname="$(echo "$fulladdr" | cut -d @ -f 2)"
 	login="${login:-$fulladdr}"
 	if [ -n "${password+x}" ]; then
 		createpass


### PR DESCRIPTION
The `hostname` variable is used in the `Message-ID` field of mails (the part after @). Currently the variable is not set by mutt-wizard and neomutt defaults to the computer hostname, which could potentially be bad for privacy. The standard seems to be to use the E-Mail server domain (Thunderbird and others do this).

https://neomutt.org/guide/reference.html#3-140-%C2%A0hostname