### PR TITLE
Make the indicator respect the attributes of the item below it.

### DIFF
--- a/share/mutt-wizard.muttrc
+++ b/share/mutt-wizard.muttrc
@@ -107,6 +107,7 @@ color index_author brightred blue "~T"
 color index_subject brightcyan blue "~T"
 
 # Other colors and aesthetic settings:
+set cursor_overlay = yes
 mono bold bold
 mono underline underline
 mono indicator reverse


### PR DESCRIPTION
Enabling cursor_overlay makes the indicator respect the attributes of the item below it. For example, if you have made the status bar show the mailboxes with new emails, in bold, and your index to show the new emails in reverse. Having set cursor_overlay = yes keeps those attributes even when the indicator is over the mailbox or email in question.