### PR TITLE
Add support for OpenBSD

### DIFF
--- a/bin/mailsync
+++ b/bin/mailsync
@@ -11,10 +11,16 @@
 # issues. It also should at least be compatible with Linux (and maybe BSD) with
 # Xorg and MacOS as well.
 
+if [ "$(uname)" == 'OpenBSD' ]; then
+  alias grep=ggrep
+  alias sed=gsed
+  alias awk=gawk
+fi
+
 # Run only if user logged in (prevent cron errors)
 pgrep -u "${USER:=$LOGNAME}" >/dev/null || { echo "$USER not logged in; sync will not run."; exit ;}
 # Run only if not already running in other instance
-pidof mbsync >/dev/null && { echo "mbsync is already running."; exit ;}
+pgrep mbsync >/dev/null && { echo "mbsync is already running."; exit ;}
 
 # First, we have to get the right variables for the mbsync file, the pass
 # archive, notmuch and the GPG home.  This is done by searching common profile
@@ -34,6 +40,17 @@ case "$(uname)" in
 	Darwin)
 		notify() { osascript -e "display notification \"$2 in $1\" with title \"You've got Mail\" subtitle \"Account: $account\"" && sleep 2 ;}
 		messageinfo() { osascript -e "display notification with title \"📧 $from\" subtitle \"$subject\"" ;}
+		;;
+	OpenBSD)
+		displays="$(pgrep -lf X11R6 | grep -wo "[0-9]*:[0-9]\+" | sort -u)"
+		notify() { [ -n "$displays" ] && for x in ${displays:-0:}; do
+				export DISPLAY=$x
+				notify-send --app-name="mutt-wizard" "mutt-wizard" "📬 $2 new mail(s) in \`$1\` account."
+			done ;}
+		messageinfo() { [ -n "$displays" ] && for x in ${displays:-0:}; do
+				export DISPLAY=$x
+				notify-send --app-name="mutt-wizard" "📧$from:" "$subject"
+			done ;}
 		;;
 	*)
 		case "$(readlink -f /sbin/init)" in

--- a/bin/mailsync
+++ b/bin/mailsync
@@ -11,16 +11,10 @@
 # issues. It also should at least be compatible with Linux (and maybe BSD) with
 # Xorg and MacOS as well.
 
-if [ "$(uname)" == 'OpenBSD' ]; then
-  alias grep=ggrep
-  alias sed=gsed
-  alias awk=gawk
-fi
-
 # Run only if user logged in (prevent cron errors)
 pgrep -u "${USER:=$LOGNAME}" >/dev/null || { echo "$USER not logged in; sync will not run."; exit ;}
 # Run only if not already running in other instance
-pgrep mbsync >/dev/null && { echo "mbsync is already running."; exit ;}
+pidof mbsync >/dev/null && { echo "mbsync is already running."; exit ;}
 
 # First, we have to get the right variables for the mbsync file, the pass
 # archive, notmuch and the GPG home.  This is done by searching common profile
@@ -40,17 +34,6 @@ case "$(uname)" in
 	Darwin)
 		notify() { osascript -e "display notification \"$2 in $1\" with title \"You've got Mail\" subtitle \"Account: $account\"" && sleep 2 ;}
 		messageinfo() { osascript -e "display notification with title \"📧 $from\" subtitle \"$subject\"" ;}
-		;;
-	OpenBSD)
-		displays="$(pgrep -lf X11R6 | grep -wo "[0-9]*:[0-9]\+" | sort -u)"
-		notify() { [ -n "$displays" ] && for x in ${displays:-0:}; do
-				export DISPLAY=$x
-				notify-send --app-name="mutt-wizard" "mutt-wizard" "📬 $2 new mail(s) in \`$1\` account."
-			done ;}
-		messageinfo() { [ -n "$displays" ] && for x in ${displays:-0:}; do
-				export DISPLAY=$x
-				notify-send --app-name="mutt-wizard" "📧$from:" "$subject"
-			done ;}
 		;;
 	*)
 		case "$(readlink -f /sbin/init)" in

--- a/bin/mailsync
+++ b/bin/mailsync
@@ -14,7 +14,7 @@
 # Run only if user logged in (prevent cron errors)
 pgrep -u "${USER:=$LOGNAME}" >/dev/null || { echo "$USER not logged in; sync will not run."; exit ;}
 # Run only if not already running in other instance
-pidof mbsync >/dev/null && { echo "mbsync is already running."; exit ;}
+pgrep mbsync >/dev/null && { echo "mbsync is already running."; exit ;}
 
 # First, we have to get the right variables for the mbsync file, the pass
 # archive, notmuch and the GPG home.  This is done by searching common profile
@@ -25,7 +25,7 @@ eval "$(grep -h -- \
 	"$HOME/.profile" "$HOME/.bash_profile" "$HOME/.zprofile"  "$HOME/.config/zsh/.zprofile" "$HOME/.zshenv" \
 	"$HOME/.bashrc" "$HOME/.zshrc" "$HOME/.config/zsh/.zshrc" "$HOME/.pam_environment" 2>/dev/null)"
 
-export GPG_TTY=$TTY
+export GPG_TTY="$(tty)"
 
 [ -n "$MBSYNCRC" ] && alias mbsync="mbsync -c $MBSYNCRC" || MBSYNCRC="$HOME/.mbsyncrc"
 

--- a/bin/mw
+++ b/bin/mw
@@ -13,6 +13,13 @@ mpoprc="${XDG_CONFIG_HOME:-$HOME/.config}/mpop/config"
 alias mbsync='mbsync -c "$mbsyncrc"'
 acctseq="1 2 3 4 5 6 7 8 9"
 
+if [ "$(uname)" == 'OpenBSD' ]; then
+  alias grep=ggrep
+  alias sed=gsed
+  alias awk=gawk
+fi
+
+
 for x in "/etc/ssl/certs/ca-certificates.crt" "/etc/pki/tls/certs/ca-bundle.crt" "/etc/ssl/ca-bundle.pem" "/etc/pki/tls/cacert.pem" "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem" "/etc/ssl/cert.pem" "/usr/local/share/ca-certificates/"; do
 	[ -f "$x" ] && sslcert="$x" && break
 done || { echo "CA Certificate not found. Please install one or link it to /etc/ssl/certs/ca-certificates.crt" && exit 1 ;}

--- a/bin/mw
+++ b/bin/mw
@@ -13,13 +13,6 @@ mpoprc="${XDG_CONFIG_HOME:-$HOME/.config}/mpop/config"
 alias mbsync='mbsync -c "$mbsyncrc"'
 acctseq="1 2 3 4 5 6 7 8 9"
 
-if [ "$(uname)" == 'OpenBSD' ]; then
-  alias grep=ggrep
-  alias sed=gsed
-  alias awk=gawk
-fi
-
-
 for x in "/etc/ssl/certs/ca-certificates.crt" "/etc/pki/tls/certs/ca-bundle.crt" "/etc/ssl/ca-bundle.pem" "/etc/pki/tls/cacert.pem" "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem" "/etc/ssl/cert.pem" "/usr/local/share/ca-certificates/"; do
 	[ -f "$x" ] && sslcert="$x" && break
 done || { echo "CA Certificate not found. Please install one or link it to /etc/ssl/certs/ca-certificates.crt" && exit 1 ;}
@@ -234,7 +227,7 @@ getboxes() { if [ -n "${force+x}" ] ; then
 		mailboxes="$(echo "$info" | grep -v HasChildren | sed "s/.*\" //;s/\"//g" | tr -d '')"
 	fi
 	[ "$type" = "pop" ] && mailboxes="INBOX"
-	getaccounts; for x in "$acctseq"; do echo "$accounts" | grep -q "^$x:" || { export idnum="$x"; break ;}; done
+	getaccounts; for x in $acctseq; do echo "$accounts" | grep -q "^$x:" || { export idnum="$x"; break ;}; done
 	toappend="mailboxes $(echo "$mailboxes" | sed "s/^/\"=/;s/$/\"/" | paste -sd ' ' - )"
 	for x in $mailboxes; do
 		case "$x" in

--- a/bin/mw
+++ b/bin/mw
@@ -11,6 +11,7 @@ msmtplog="${XDG_CONFIG_HOME:-$HOME/.config}/msmtp/msmtp.log"
 mbsyncrc="${MBSYNCRC:-$HOME/.mbsyncrc}"
 mpoprc="${XDG_CONFIG_HOME:-$HOME/.config}/mpop/config"
 alias mbsync='mbsync -c "$mbsyncrc"'
+acctseq="1 2 3 4 5 6 7 8 9"
 
 for x in "/etc/ssl/certs/ca-certificates.crt" "/etc/pki/tls/certs/ca-bundle.crt" "/etc/ssl/ca-bundle.pem" "/etc/pki/tls/cacert.pem" "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem" "/etc/ssl/cert.pem" "/usr/local/share/ca-certificates/"; do
 	[ -f "$x" ] && sslcert="$x" && break
@@ -226,7 +227,7 @@ getboxes() { if [ -n "${force+x}" ] ; then
 		mailboxes="$(echo "$info" | grep -v HasChildren | sed "s/.*\" //;s/\"//g" | tr -d '')"
 	fi
 	[ "$type" = "pop" ] && mailboxes="INBOX"
-	getaccounts; for x in $(seq 1 9); do echo "$accounts" | grep -q "^$x:" || { export idnum="$x"; break ;}; done
+	getaccounts; for x in "$acctseq"; do echo "$accounts" | grep -q "^$x:" || { export idnum="$x"; break ;}; done
 	toappend="mailboxes $(echo "$mailboxes" | sed "s/^/\"=/;s/$/\"/" | paste -sd ' ' - )"
 	for x in $mailboxes; do
 		case "$x" in


### PR DESCRIPTION
Hi,

The following change add support for OpenBSD by:
* using gnu sed/grep/awk instead of sed/grep/awk in OpenBSD base system
* replace pidof(1) with pgrep(1) for detecting existing process of mbsync
* change pgrep(1) command for getting the full argument list and thus get the display ID
* replace `seq 1 9` with a hardcoded string for everyone, this eliminate the need for seq(1) 

Tested on OpenBSD 6.9 -current amd64. Please help me review & merge this, thanks! 