### PR TITLE
Add uclive.ac.nz domains

### DIFF
--- a/share/domains.csv
+++ b/share/domains.csv
@@ -281,6 +281,7 @@ txstate.edu,outlook.office365.com,993,smtp.office365.com,587
 ua.pt,outlook.office365.com,993,mail.ua.pt,25
 uach.mx,imap.gmail.com,993,smtp.gmail.com,587
 ucdavis.edu,imap.gmail.com,993,smtp.gmail.com,587
+uclive.ac.nz,outlook.office365.com,993,smtp.office365.com,587
 ucsb.edu,imap.gmail.com,993,smtp.gmail.com,587
 ucsc.edu,imap.gmail.com,993,smtp.gmail.com,587
 uni-duesseldorf.de,mail.hhu.de,993,mail.hhu.de,465


### PR DESCRIPTION
Add domains for uclive.ac.nz addresses. These are undergrad (and maybe other) addresses for the University of Canterbury (https://canterbury.ac.nz/).