### PR TITLE
Added NOVA School of Science and Technology domains

### DIFF
--- a/share/domains.csv
+++ b/share/domains.csv
@@ -45,6 +45,7 @@ brew-meister.com,imap.mail.com,993,smtp.mail.com,587
 bruttocarattere.org,mail.autistici.org,993,smtp.autistici.org,465
 btinternet.com,mail.btinternet.com,993,mail.btinternet.com,587
 calstatela.edu,outlook.office365.com,993,smtp.office365.com,587
+campus.fct.unl.pt,imap.gmail.com,993,smtp.gmail.com,587
 canaglie.net,mail.autistici.org,993,smtp.autistici.org,465
 canaglie.org,mail.autistici.org,993,smtp.autistici.org,465
 carleton.ca,imap-mail.outlook.com,993,smtp-mail.outlook.com,587
@@ -100,6 +101,7 @@ europe.com,imap.mail.com,993,smtp.mail.com,587
 ex-studenti.unitn.it,imap.gmail.com,993,smtp.gmail.com,587
 fastmail.com,imap.fastmail.com,993,smtp.fastmail.com,465
 fastmail.fm,imap.fastmail.com,993,smtp.fastmail.com,465
+fct.unl.pt,imap.gmail.com,993,smtp.gmail.com,587
 firemail.cc,mail.cock.li,993,mail.cock.li,587
 forpsi.com,imap.forpsi.com,993,smtp.forpsi.com,465
 forthnet.gr,mail.forthnet.gr,993,smtp-auth.forthnet.gr,465


### PR DESCRIPTION
Added the two domains used by the [NOVA School of Science and technology](https://fct.unl.pt/en) (fct.unl.pt and campus.fct.unl.pt).