### PR TITLE
Fix: remove extra `\` from dynamic mailboxes

### DIFF
--- a/bin/mw
+++ b/bin/mw
@@ -226,7 +226,7 @@ getboxes() { if [ -n "${force+x}" ] ; then
 		idnum=$((idnum + 1))
 		[ $idnum -eq $x ] || break
 	done
-	toappend="mailboxes \`mdir=$maildir/$fulladdr/; find \$mdir -mindepth 1 -type d -name cur | sed -e 's:/cur\$:\":' -e \"s:\$mdir:\\\"=:\" | sort | tr '\\\n' ' '\`"
+	toappend="mailboxes \`mdir=$maildir/$fulladdr/; find \$mdir -mindepth 1 -type d -name cur | sed -e 's:/cur\$:\":' -e \"s:\$mdir:\\\"=:\" | sort | tr '\\n' ' '\`"
 }
 
 finalize() { echo "$toappend" >> "$accdir/$fulladdr.muttrc"


### PR DESCRIPTION
Remove extra escaping from `mutt`'s mailboxes dynamic generator.
Apparently, backslash expansion inside the backticks context
(`\`shell-command\``) is not performed.

Fixes #769.