### PR TITLE
Cleanup reorder account numbers action

### DIFF
--- a/bin/mw
+++ b/bin/mw
@@ -308,23 +308,27 @@ To change an account's password, run \`pass edit your@email.com\`.
 EOF
 }
 
-reorder(){
+reorder() {
 	tempfile="$(mktemp -u)"
 	trap 'rm -f $tempfile' HUP INT QUIT TERM PWR EXIT
-	echo "# Carefully reorder these accounts with the desired numbers." > "$tempfile"
+  echo "# Carefully reorder these accounts with the desired numbers in the first column.
+# DO NOT reorder rows or rename the accounts in the second column." > "$tempfile"
 	sed -n "
 	/ i[0-9] / s?\(.* i\|'<sync.*/\|\.muttrc.*\)??g p
-	" "$muttrc" > "$tempfile"
+	" "$muttrc" >> "$tempfile"
 	${EDITOR:-vim} "$tempfile" || exit 1
+  sed -i -e 's/#.*//' -e '/^$/d' "$tempfile"
 	default="$(sort -n "$tempfile" | head -n 1)"
 	default="${default#* }"
-	sed -ibu "/.* i[0-9] .*.muttrc/d" "$muttrc" 2>/dev/null; rm -f "$muttrc"bu
+	sed -ibu "
+  /.* i[0-9] .*.muttrc/d
+  /^source.*accounts.*.muttrc/d
+  " "$muttrc" 2>/dev/null; rm -f "$muttrc"bu
 	awk -v a="$accdir" -v d="$default" ' BEGIN { print "source "a"/"d".muttrc" }
 		{
 		print "macro index,pager i"$1" '\''<sync-mailbox><enter-command>source "a"/"$2".muttrc<enter><change-folder>!<enter>;<check-stats>'\'' \"switch to "$2"\""
 		}
 	' "$tempfile" >> "$muttrc"
-
 }
 
 while getopts "rfpPXlhodTYD:y:i:I:s:S:u:a:n:x:m:t:" o; do case "${o}" in


### PR DESCRIPTION
Refactors commit 85c5d01

* Keep the comment(s) when reordering account numbers in temp file. Users
  may accidently reorder rows or rename accounts rather than update order number.
* Remove original default config from muttrc.  Currently, script only removes the
  macro shortcuts .If you run reorder action multiple times, you'll end up sourcing
  multiple "default" config files.