### PR TITLE
Fix html links splitting

### DIFF
--- a/share/mailcap
+++ b/share/mailcap
@@ -1,6 +1,6 @@
 text/plain; $EDITOR %s ;
 text/html; openfile %s ; nametemplate=%s.html
-text/html; lynx -assume_charset=%{charset} -display_charset=utf-8 -dump %s; nametemplate=%s.html; copiousoutput;
+text/html; lynx -assume_charset=%{charset} -display_charset=utf-8 -dump -width=1024 %s; nametemplate=%s.html; copiousoutput;
 image/*; openfile %s ;
 video/*; setsid mpv --quiet %s &; copiousoutput
 audio/*; mpv %s ;


### PR DESCRIPTION
avoid line splitting.
the width option is set to 80 by default, increasing it will avoid breaking long links in two different lines