### PR TITLE
Make gentoo users aware that they need the "sasl" for the neomutt package

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Specifically, this wizard:
 
 #### Dependencies
 
-- `neomutt` - the email client.
+- `neomutt` - the email client. (If you are using Gentoo GNU/Linux, you will need the `sasl` use flag to be enabled)
 - `curl` - tests connections (required at install).
 - `isync` - downloads and syncs the mail (required if storing IMAP mail locally).
 - `msmtp` - sends the email.


### PR DESCRIPTION
Hi Luke,

If you are using Gentoo, you will need to have the "sasl" use flag enabled(issues #633 , #604 ).
I had the same problem and it would be good for future users to know that when they are installing the package.

With kind regards
Lorenz