### PR TITLE
Wrap text when reading emails at 80 chars

### DIFF
--- a/share/mutt-wizard.muttrc
+++ b/share/mutt-wizard.muttrc
@@ -27,6 +27,7 @@ auto_view text/html		# automatically show html (mailcap uses lynx)
 auto_view application/pgp-encrypted
 #set display_filter = "tac | sed '/\\\[-- Autoview/,+1d' | tac" # Suppress autoview messages.
 alternative_order text/plain text/enriched text/html
+set width = 80 # wordwrap when reading emails
 
 bind index,pager i noop
 bind index,pager g noop


### PR DESCRIPTION
For increased legibility.
