### PR TITLE
Hard link the file instead of copying

### DIFF
--- a/bin/openfile
+++ b/bin/openfile
@@ -5,6 +5,6 @@ tempdir="${XDG_CACHE_HOME:-$HOME/.cache}/mutt-wizard/files"
 file="$tempdir/$(basename "$1")"
 [ "$(uname)" = "Darwin" ] && opener="open" || opener="setsid -f xdg-open"
 mkdir -p "$tempdir"
-cp -f "$1" "$file"
+ln "$1" "$file"
 $opener "$file" >/dev/null 2>&1
 find "${tempdir:?}" -mtime +1 -type f -delete


### PR DESCRIPTION
In the latest neomutt release (2022-04-08), neomutt/neomutt/pull/3267 is
merged. Neomutt doesn't overwrite files with zeros on closing anymore,
just unlinks it. Therefore, instead of copying, files can be hard
linked.
