### PR TITLE
Force hard linking the file

### DIFF
--- a/bin/openfile
+++ b/bin/openfile
@@ -5,6 +5,6 @@ tempdir="${XDG_CACHE_HOME:-$HOME/.cache}/mutt-wizard/files"
 file="$tempdir/$(basename "$1")"
 [ "$(uname)" = "Darwin" ] && opener="open" || opener="setsid -f xdg-open"
 mkdir -p "$tempdir"
-ln "$1" "$file"
+ln -f "$1" "$file"
 $opener "$file" >/dev/null 2>&1
 find "${tempdir:?}" -mtime +1 -type f -delete


### PR DESCRIPTION
It was forgotten to add `--force` option for `ln` in 95687867d1795299625e1e3dc5cdc412155de879. This enables opening files with the same names, but different contents, with a new NeoMutt instance, after the previous is closed.
