### PR TITLE
fix notifications when the Xorg process is just X

### DIFF
--- a/bin/mailsync
+++ b/bin/mailsync
@@ -42,7 +42,7 @@ case "$(uname)" in
 			*systemd*|*openrc*) export DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/$(id -u)/bus ;;
 		esac
 		# remember if a display server is running since `ps` doesn't always contain a display
-		pgrepoutput="$(pgrep -a X\(org\|wayland\))"
+		pgrepoutput="$(pgrep -ax X\(\|org\|wayland\))"
 		displays="$(echo "$pgrepoutput" | grep -wo "[0-9]*:[0-9]\+" | sort -u)"
 		notify() { [ -n "$pgrepoutput" ] && for x in ${displays:-0:}; do
 				export DISPLAY=$x


### PR DESCRIPTION
To close #845 :

I added the `-x` flag to prevent the regex from matching on _every_ pro-
cess name containing an `X`.

Because I'm not entirely sure about portability (does every `pgrep` va-
riant support that flag), I didn't push this directly.

So what do you think @LukeSmithxyz ?