### PR TITLE
Silence mailsync, so cron doesn't spam e-mails on every update

### DIFF
--- a/bin/mailsync
+++ b/bin/mailsync
@@ -70,14 +70,13 @@ syncandnotify() {
 }
 
 # Sync accounts passed as argument or all.
-if [ "$#" -eq "0" ]; then
-    accounts="$(awk '/^Channel/ {print $2}' "$MBSYNCRC")"
-else
+if [ "$#" -gt "0" ]; then
     for arg in "$@"; do
         [ "${arg%${arg#?}}" = '-' ] && opts="${opts:+${opts} }${arg}" && shift 1
     done
     accounts=$*
 fi
+[[ ! $accounts ]] && accounts="$(awk '/^Channel/ {print $2}' "$MBSYNCRC")"
 
 # Parallelize multiple accounts
 for account in $accounts; do
@@ -86,7 +85,7 @@ done
 
 wait
 
-notmuch new 2>/dev/null
+notmuch new --quiet
 
 #Create a touch file that indicates the time of the last run of mailsync
 touch "$lastrun"

--- a/bin/mw
+++ b/bin/mw
@@ -262,7 +262,7 @@ togglecron() { cron="$(mktemp)"
 		sed -ibu /mailsync/d "$cron"; rm -f "$cron"bu
 	else
 		echo "Adding automatic mailsync every ${cronmin:-10} minutes..."
-		echo "*/${cronmin-10} * * * * $prefix/bin/mailsync" >> "$cron"
+		echo "*/${cronmin:-10} * * * * $prefix/bin/mailsync -q" >> "$cron"
 	fi &&
 	crontab "$cron"; rm -f "$cron" ;}
 


### PR DESCRIPTION
Cron jobs must be silent, or they will send e-mails to the crontab user with the output. These e-mails can be useful if there is an error, but during normal operation they quickly accumulate to astronomical proportions; especially if the cron job is configured to run every x minutes.

This commit silences the cron job avoiding the spam when there is no error.