### PR TITLE
(README.md) put keyboard shortcuts in <kbd> tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ A user of Arch-based distros can also install the current mutt-wizard release fr
 - `notmuch` - index and search mail. Install it and run `notmuch setup`, tell
   it that your mail is in `~/.local/share/mail/` (although `mw` will do this
   automatically if you haven't set notmuch up before). You can run it in mutt
-  with `ctrl-f`. Run `notmuch new` to process new mail.
+  with <kbd>ctrl-f</kbd>. Run `notmuch new` to process new mail.
 - `abook` - a terminal-based address book. Pressing tab while typing an address
   to send mail to will suggest contacts that are in your abook.
 - `urlview` - outputs urls in mail to browser.
@@ -110,25 +110,25 @@ The mutt-wizard runs via the command `mw`. Once setup is complete, you'll use
 
 To give you an example of the interface, here's an idea:
 
-- `m` - send mail (uses your default `$EDITOR` to write)
-- `j`/`k` and `d`/`u` - vim-like bindings to go down and up (or `d`/`u` to go
+- <kbd>m</kbd> - send mail (uses your default `$EDITOR` to write)
+- <kbd>j</kbd>/<kbd>k</kbd> and <kbd>d</kbd>/<kbd>u</kbd> - vim-like bindings to go down and up (or <kbd>d</kbd>/<kbd>u</kbd> to go
   down/up a page).
-- `l` - open mail, or attachment page or attachment
-- `h` - the opposite of `l`
-- `r`/`R` - reply/reply all to highlighted mail
-- `s` - save selected mail or selected attachment
-- `gs`,`gi`,`ga`,`gd`,`gS` - Press `g` followed by another letter to change
-  mailbox: `s`ent, `i`nbox, `a`rchive, `d`rafts, `S`pam, etc.
-- `M` and `C` - For `M`ove and `C`opy: follow them with one of the mailbox
-  letters above, i.e. `MS` means "move to Spam".
-- `i#` - Press `i` followed by a number 1-9 to go to a different account. If you
+- <kbd>l</kbd> - open mail, or attachment page or attachment
+- <kbd>h</kbd> - the opposite of <kbd>l</kbd>
+- <kbd>r</kbd>/<kbd>R</kbd> - reply/reply all to highlighted mail
+- <kbd>s</kbd> - save selected mail or selected attachment
+- <kbd>gs</kbd>,<kbd>gi</kbd>,<kbd>ga</kbd>,<kbd>gd</kbd>,<kbd>gS</kbd> - Press <kbd>g</kbd> followed by another letter to change
+  mailbox: <kbd>s</kbd>ent, <kbd>i</kbd>nbox, <kbd>a</kbd>rchive, <kbd>d</kbd>rafts, <kbd>S</kbd>pam, etc.
+- <kbd>M</kbd> and <kbd>C</kbd> - For <kbd>M</kbd>ove and <kbd>C</kbd>opy: follow them with one of the mailbox
+  letters above, i.e. <kbd>MS</kbd> means "move to Spam".
+- <kbd>i#</kbd> - Press <kbd>i</kbd> followed by a number 1-9 to go to a different account. If you
   add 9 accounts via mutt-wizard, they will each be assigned a number.
-- `a` to add address/person to abook and `Tab` while typing address to complete
+- <kbd>a</kbd> to add address/person to abook and <kbd>Tab</kbd> while typing address to complete
   one from abook.
-- `?` - see all keyboard shortcuts
-- `ctrl-j`/`ctrl-k` - move up and down in sidebar, `ctrl-o` opens mailbox.
-- `ctrl-b` - open a menu to select a URL you want to open in your browser.
-- `p` - encrypt/sign your message (in compose view, before sending the email).
+- <kbd>?</kbd> - see all keyboard shortcuts
+- <kbd>ctrl-j</kbd>/<kbd>ctrl-k</kbd> - move up and down in sidebar, <kbd>ctrl-o</kbd> opens mailbox.
+- <kbd>ctrl-b</kbd> - open a menu to select a URL you want to open in your browser.
+- <kbd>p</kbd> - encrypt/sign your message (in compose view, before sending the email).
 
 ## Additional functionality
 
@@ -139,7 +139,7 @@ To give you an example of the interface, here's an idea:
 - `notmuch` - Index and search mail. Install it and run `notmuch setup`, tell it
   that your mail is in `~/.local/share/mail/` (although `mw` will do this
   automatically if you haven't set notmuch up before). You can run it in mutt
-  with `ctrl-f`. Run `notmuch new` to process new mail.
+  with <kbd>ctrl-f</kbd>. Run `notmuch new` to process new mail.
 - `abook` - A terminal-based address book. Pressing tab while typing an address
   to send mail to will suggest contacts that are in your abook.
 - `urlview` - Outputs URLs in an email to your browser.


### PR DESCRIPTION
Helps distinguish them from other commands/files in the README

Surrounded in `` ` ``:
`m` - send mail (uses your default `$EDITOR` to write)
Surrounded in `<kbd>`:
<kbd>m</kbd> - send mail (uses your default `$EDITOR` to write)