### PR TITLE
Add Support for POP3 Notification

### DIFF
--- a/bin/mailsync
+++ b/bin/mailsync
@@ -19,7 +19,7 @@ pgrep mbsync >/dev/null && { echo "mbsync is already running."; exit ;}
 # files for variable assignments. This is ugly, but there are few options that
 # will work on the maximum number of machines.
 eval "$(grep -h -- \
-	"^\s*\(export \)\?\(MBSYNCRC\|PASSWORD_STORE_DIR\|NOTMUCH_CONFIG\|GNUPGHOME\)=" \
+	"^\s*\(export \)\?\(MBSYNCRC\|MPOPRC\|PASSWORD_STORE_DIR\|NOTMUCH_CONFIG\|GNUPGHOME\)=" \
 	"$HOME/.profile" "$HOME/.bash_profile" "$HOME/.zprofile"  "$HOME/.config/zsh/.zprofile" "$HOME/.zshenv" \
 	"$HOME/.config/zsh/.zshenv" "$HOME/.bashrc" "$HOME/.zshrc" "$HOME/.config/zsh/.zshrc" \
 	"$HOME/.pam_environment" 2>/dev/null)"
@@ -27,6 +27,7 @@ eval "$(grep -h -- \
 export GPG_TTY="$(tty)"
 
 [ -n "$MBSYNCRC" ] && alias mbsync="mbsync -c $MBSYNCRC" || MBSYNCRC="$HOME/.mbsyncrc"
+[ -n "$MPOPRC" ] || MPOPRC="$HOME/.config/mpop/config"
 
 lastrun="${XDG_CONFIG_HOME:-$HOME/.config}/mutt/.mailsynclastrun"
 
@@ -52,7 +53,13 @@ esac
 # Check account for new mail. Notify if there is new content.
 syncandnotify() {
     acc="$(echo "$account" | sed "s/.*\///")"
-    if [ -z "$opts" ]; then mbsync "$acc"; else mbsync "$opts" "$acc"; fi
+    if [ "$1" = "pop" ]; then
+        # Handle POP
+        mpop "$acc"
+    else 
+        # Handle IMAP
+        if [ -z "$opts" ]; then mbsync "$acc"; else mbsync "$opts" "$acc"; fi
+    fi
     new=$(find\
 	"$HOME/.local/share/mail/$acc/"[Ii][Nn][Bb][Oo][Xx]/new/\
 	"$HOME/.local/share/mail/$acc/"[Ii][Nn][Bb][Oo][Xx]/cur/\
@@ -70,11 +77,17 @@ if [ "$#" -gt "0" ]; then
     done
     accounts=$*
 fi
+# TODO handle account passed from argument
 [ -z "$accounts" ] && accounts="$(awk '/^Channel/ {print $2}' "$MBSYNCRC")"
+[ -z "$pop_accounts" ] && pop_accounts="$(awk '/^account/ {print $2}' "$MPOPRC")"
 
 # Parallelize multiple accounts
 for account in $accounts; do
-    syncandnotify &
+    syncandnotify "imap" &
+done
+
+for account in $pop_accounts; do
+    syncandnotify "pop" &
 done
 
 wait


### PR DESCRIPTION
- This PR Adds the Patch in #866 Issue. 
- Add feature of Notifications on new Email for POP3 using `mpop`.