### PR TITLE
Fix spelling in manpages

### DIFF
--- a/mailsync.1
+++ b/mailsync.1
@@ -44,7 +44,7 @@ account.
 See the
 .B
 mbsync
-manual for aditional options that can be used.
+manual for additional options that can be used.
 .SH AUTHORS
 Written by Luke Smith <luke@lukesmith.xyz> originally in 2018.
 .SH LICENSE

--- a/mw.1
+++ b/mw.1
@@ -237,7 +237,7 @@ replies to the selected message;
 .I R
 replies all to the selected message and
 .I f
-fowards the selected message.
+forwards the selected message.
 .TP
 .B Compose mail screen
 Once you write mail and save the buffer you will be brought to the compose screen. Press


### PR DESCRIPTION
Follows fix spelling in the manual files (mailsync.1 and mw.1) according to the packaging in Debian, because I am the co-maintainer of the package in Debian.