### PR TITLE
fix: make o and O macro work and really sync multiple/individual accounts

### DIFF
--- a/bin/mailsync
+++ b/bin/mailsync
@@ -77,16 +77,27 @@ if [ "$#" -gt "0" ]; then
 	done
 	accounts=$*
 fi
-# TODO handle account passed from argument
-[ -z "$accounts" ] && accounts="$(awk '/^Channel/ {print $2}' "$MBSYNCRC" 2>/dev/null)"
-[ -z "$pop_accounts" ] && [ -x $MPOPRC ] && pop_accounts="$(awk '/^account/ {print $2}' "$MPOPRC" 2>/dev/null)"
+[ -z "$imap_accounts" ] && [ -r "$MBSYNCRC" ] && imap_accounts="$(awk '/^Channel/ {print $2}' "$MBSYNCRC" 2>/dev/null)"
+[ -z "$pop_accounts" ] && [ -r "$MPOPRC" ] && pop_accounts="$(awk '/^account/ {print $2}' "$MPOPRC" 2>/dev/null)"
 
 # Parallelize multiple accounts
-for account in $accounts; do
+for account in $imap_accounts; do
+	if [ -n "$accounts" ]; then
+		for tmp_ac in $accounts; do
+			[ "$tmp_ac" = "$account" ] && syncandnotify "imap" &
+		done
+		continue
+	fi
 	syncandnotify "imap" &
 done
 
 for account in $pop_accounts; do
+	if [ -n "$accounts" ]; then
+		for tmp_ac in $accounts; do
+			[ "$tmp_ac" = "$account" ] && syncandnotify "pop" &
+		done
+		continue
+	fi
 	syncandnotify "pop" &
 done
 


### PR DESCRIPTION
it was always sync all accounts though just emit `o`, and `O` seems was useless if so.
now `TODO handle account passed from argument` such should have been solved, which can sync only specific account, or none parameters then all accounts.

Signed-off-by: shane.xb.qian <shane.qian@foxmail.com>