### PR TITLE
read xorg displays from unix-domain socket if pgrep returns null

### DIFF
--- a/bin/mailsync
+++ b/bin/mailsync
@@ -43,6 +43,8 @@ case "$(uname)" in
 		# remember if a display server is running since `ps` doesn't always contain a display
 		pgrepoutput="$(pgrep -ax X\(\|org\|wayland\))"
 		displays="$(echo "$pgrepoutput" | grep -wo "[0-9]*:[0-9]\+" | sort -u)"
+		[ -z $displays ] && [ -d /tmp/.X11-unix ] && displays=$(cd /tmp/.X11-unix && for x in X*; do echo ":${x#X}"; done)
+
 		notify() { [ -n "$pgrepoutput" ] && for x in ${displays:-0:}; do
 				export DISPLAY=$x
 				notify-send --app-name="mutt-wizard" "New mail!" "📬 $2 new mail(s) in \`$1\` account."


### PR DESCRIPTION
On my i3wm with slim (1.3.6) and xorg (1:7.7+22) setup, pgrep doesn't return my display and it falls back to default display "0:" as expected. But this default display doesn't work on my PC so notify-send doesn't work.

I added this safe line so script can read current displays from /tmp/.X11-unix if it exists.