### PR TITLE
read-in env vars properly if dependent on XDG Standard

### DIFF
--- a/bin/mailsync
+++ b/bin/mailsync
@@ -19,7 +19,7 @@ pgrep mbsync >/dev/null && { echo "mbsync is already running."; exit ;}
 # files for variable assignments. This is ugly, but there are few options that
 # will work on the maximum number of machines.
 eval "$(grep -h -- \
-	"^\s*\(export \)\?\(MBSYNCRC\|MPOPRC\|PASSWORD_STORE_DIR\|NOTMUCH_CONFIG\|GNUPGHOME\|MAILSYNC_MUTE\)=" \
+	"^\s*\(export \)\?\(MBSYNCRC\|MPOPRC\|PASSWORD_STORE_DIR\|PASSWORD_STORE_GPG_OPTS\|NOTMUCH_CONFIG\|GNUPGHOME\|MAILSYNC_MUTE\|XDG_CONFIG_HOME\|XDG_DATA_HOME\)=" \
 	"$HOME/.profile" "$HOME/.bash_profile" "$HOME/.zprofile"  "$HOME/.config/zsh/.zprofile" "$HOME/.zshenv" \
 	"$HOME/.config/zsh/.zshenv" "$HOME/.bashrc" "$HOME/.zshrc" "$HOME/.config/zsh/.zshrc" \
 	"$HOME/.pam_environment" 2>/dev/null)"


### PR DESCRIPTION
I've noticed that the cronjob env var read-in did not work for me since my vars where dependent on `XDG_DATA_HOME` (typically `~/.local/share`) and `XDG_CONFIG_HOME` (typically `~/.config`).
This seems like it could also be an issue for others so i though i could add this PR.

Additionally to that I've also added the env var `PASSWORD_STORE_GPG_OPTS` as it can also affect pass behaviour.