### PR TITLE
fix: mailsync looks no '-q' parameter or made it fail

### DIFF
--- a/bin/mw
+++ b/bin/mw
@@ -217,7 +217,7 @@ togglecron() { cron="$(mktemp)"
 		sed -ibu /mailsync/d "$cron"; rm -f "$cron"bu
 	else
 		echo "Adding automatic mailsync every ${cronmin:-10} minutes..."
-		echo "*/${cronmin:-10} * * * * $prefix/bin/mailsync -q" >> "$cron"
+		echo "*/${cronmin:-10} * * * * $prefix/bin/mailsync" >> "$cron"
 	fi &&
 	crontab "$cron"; rm -f "$cron" ;}
 


### PR DESCRIPTION
// solution: remove '-q'

Signed-off-by: shane.xb.qian <shane.qian@foxmail.com>