### PR TITLE
Add highlighting for flagged emails

### DIFF
--- a/share/mutt-wizard.muttrc
+++ b/share/mutt-wizard.muttrc
@@ -133,6 +133,11 @@ color index brightyellow blue "~T"
 color index_author brightred blue "~T"
 color index_subject brightcyan blue "~T"
 
+# Flagged mail is highlighted:
+color index brightgreen default "~F"
+color index_subject brightgreen default "~F"
+color index_author brightgreen default "~F"
+
 # Other colors and aesthetic settings:
 mono bold bold
 mono underline underline


### PR DESCRIPTION
Highlighting flagged messages comes real handy. I experimented a bit with the coloring and found one that works well with both unread and tagged mail highlighting, solving https://github.com/LukeSmithxyz/mutt-wizard/issues/325#issuecomment-569430193

![flagged_messages_nmutt](https://user-images.githubusercontent.com/15214418/232142425-c8cdd7ac-b2b0-4aa2-896c-d0c125174a60.gif)


