### PR TITLE
Forward email body as text

### DIFF
--- a/share/mutt-wizard.muttrc
+++ b/share/mutt-wizard.muttrc
@@ -15,7 +15,8 @@ set rfc2047_parameters = yes
 set sleep_time = 0		# Pause 0 seconds for informational messages
 set markers = no		# Disables the `+` displayed at line wraps
 set mark_old = no		# Unread mail stay unread until read
-set mime_forward = yes		# attachments are forwarded with mail
+set mime_forward = no	# mail body is forwarded as text
+set forward_attachments = yes	# attachments are forwarded with mail
 set wait_key = no		# mutt won't ask "press key to continue"
 set fast_reply			# skip to compose when replying
 set fcc_attach			# save attachments with the body


### PR DESCRIPTION
This sends the email body as text in the forwarded message instead of an `eml` attachment. Attachments are still sent as attachments.

It's useful when you don't want to forward the whole thread as it allows you to delete stuff from it. 

Also once a colleague had trouble when opening the `eml` attachment I sent, but this was probably an issue with her mail client.