### PR TITLE
allow user to provide self-signed certificate

### DIFF
--- a/bin/mw
+++ b/bin/mw
@@ -397,7 +397,7 @@ while getopts "rfpXlhodTYD:y:i:I:s:S:u:a:n:P:x:m:t:c:" o; do case "${o}" in
 	c)
 		setact add
 		sslcert="$OPTARG"
-        curlarg="$curlarg -k"
+		curlarg="$curlarg -k"
 		;;
 	X)
 		setact delete

--- a/bin/mw
+++ b/bin/mw
@@ -214,8 +214,7 @@ getboxes() {
 	if [ -n "${force+x}" ]; then
 		mailboxes="$(printf "INBOX\\nDrafts\\nJunk\\nTrash\\nSent\\nArchive")"
 	else
-        [ ! -z "$sslcertself" ] && addarg="-k"
-		info="$(curl "$addarg" --location-trusted -s -m 5 --user "$login:$(pass "$passprefix$fulladdr")" --url "${protocol:-imaps}://$imap:${iport:-993}")"
+		info="$(curl "$curlarg" --location-trusted -s -m 5 --user "$login:$(pass "$passprefix$fulladdr")" --url "${protocol:-imaps}://$imap:${iport:-993}")"
 		[ -z "$info" ] && errorexit
 		mailboxes="$(echo "$info" | grep -v HasChildren | sed "s/.*\" //;s/\"//g" | tr -d '\r')"
 	fi
@@ -397,8 +396,8 @@ while getopts "rfpXlhodTYD:y:i:I:s:S:u:a:n:P:x:m:t:c:" o; do case "${o}" in
 		;;
 	c)
 		setact add
-		sslcertself="$OPTARG"
 		sslcert="$OPTARG"
+        curlarg="$curlarg -k"
 		;;
 	X)
 		setact delete

--- a/bin/mw
+++ b/bin/mw
@@ -214,7 +214,9 @@ getboxes() {
 	if [ -n "${force+x}" ]; then
 		mailboxes="$(printf "INBOX\\nDrafts\\nJunk\\nTrash\\nSent\\nArchive")"
 	else
-		info="$(curl "$curlarg" --location-trusted -s -m 5 --user "$login:$(pass "$passprefix$fulladdr")" --url "${protocol:-imaps}://$imap:${iport:-993}")"
+        [ -n "$sslcert" ] \
+		    && info="$(curl --location-trusted -s -m 5 --user "$login:$(pass "$passprefix$fulladdr")" --url "${protocol:-imaps}://$imap:${iport:-993}")" \
+		    || info="$(curl -k --location-trusted -s -m 5 --user "$login:$(pass "$passprefix$fulladdr")" --url "${protocol:-imaps}://$imap:${iport:-993}")"
 		[ -z "$info" ] && errorexit
 		mailboxes="$(echo "$info" | grep -v HasChildren | sed "s/.*\" //;s/\"//g" | tr -d '\r')"
 	fi
@@ -397,7 +399,6 @@ while getopts "rfpXlhodTYD:y:i:I:s:S:u:a:n:P:x:m:t:c:" o; do case "${o}" in
 	c)
 		setact add
 		sslcert="$OPTARG"
-		curlarg="$curlarg -k"
 		;;
 	X)
 		setact delete

--- a/bin/mw
+++ b/bin/mw
@@ -209,8 +209,8 @@ getboxes() {
 		mailboxes="$(printf "INBOX\\nDrafts\\nJunk\\nTrash\\nSent\\nArchive")"
 	else
         [ -n "$sslcert" ] \
-		    && info="$(curl --location-trusted -s -m 5 --user "$login:$(pass "$passprefix$fulladdr")" --url "${protocol:-imaps}://$imap:${iport:-993}")" \
-		    || info="$(curl -k --location-trusted -s -m 5 --user "$login:$(pass "$passprefix$fulladdr")" --url "${protocol:-imaps}://$imap:${iport:-993}")"
+			&& info="$(curl --location-trusted -s -m 5 --user "$login:$(pass "$passprefix$fulladdr")" --url "${protocol:-imaps}://$imap:${iport:-993}")" \
+			|| info="$(curl -k --location-trusted -s -m 5 --user "$login:$(pass "$passprefix$fulladdr")" --url "${protocol:-imaps}://$imap:${iport:-993}")"
 		[ -z "$info" ] && errorexit
 		mailboxes="$(echo "$info" | grep -v HasChildren | sed "s/.*\" //;s/\"//g" | tr -d '\r')"
 	fi

--- a/bin/mw
+++ b/bin/mw
@@ -214,7 +214,8 @@ getboxes() {
 	if [ -n "${force+x}" ]; then
 		mailboxes="$(printf "INBOX\\nDrafts\\nJunk\\nTrash\\nSent\\nArchive")"
 	else
-		info="$(curl --location-trusted -s -m 5 --user "$login:$(pass "$passprefix$fulladdr")" --url "${protocol:-imaps}://$imap:${iport:-993}")"
+        [ ! -z "$sslcertself" ] && addarg="-k"
+		info="$(curl "$addarg" --location-trusted -s -m 5 --user "$login:$(pass "$passprefix$fulladdr")" --url "${protocol:-imaps}://$imap:${iport:-993}")"
 		[ -z "$info" ] && errorexit
 		mailboxes="$(echo "$info" | grep -v HasChildren | sed "s/.*\" //;s/\"//g" | tr -d '\r')"
 	fi
@@ -294,6 +295,7 @@ Options allowed with -a:
   -X	Delete an account's local email too when deleting.
   -o	Configure address, but keep mail online.
   -f	Assume typical English mailboxes without attempting log-on.
+  -c	Path to self-signed TLS certificate.
 
 NOTE: Once at least one account is added, you can run
 \`mbsync -a\` to begin downloading mail.
@@ -326,7 +328,7 @@ reorder() {
 	' "$tempfile" >>"$muttrc"
 }
 
-while getopts "rfpXlhodTYD:y:i:I:s:S:u:a:n:P:x:m:t:" o; do case "${o}" in
+while getopts "rfpXlhodTYD:y:i:I:s:S:u:a:n:P:x:m:t:c:" o; do case "${o}" in
 	l) setact list ;;
 	r) setact reorder1 ;;
 	d) setact delete ;;
@@ -392,6 +394,11 @@ while getopts "rfpXlhodTYD:y:i:I:s:S:u:a:n:P:x:m:t:" o; do case "${o}" in
 	x)
 		setact add
 		password="$OPTARG"
+		;;
+	c)
+		setact add
+		sslcertself="$OPTARG"
+		sslcert="$OPTARG"
 		;;
 	X)
 		setact delete

--- a/mw.1
+++ b/mw.1
@@ -70,8 +70,12 @@ SMTP server port (assumed to be 465 if not specified)
 .TP
 .B -x
 Account password. You will be prompted for the password interactively if this option is not given.
+.TP
 .B -P
 Pass Prefix. The password will be stored using pass at <passprefix><email>
+.TP
+.B -c certificate
+Self-signed TLS certificate
 .SH OTHER OPTIONS
 .TP
 .B -f

--- a/mw.1
+++ b/mw.1
@@ -74,8 +74,8 @@ Account password. You will be prompted for the password interactively if this op
 .B -P
 Pass Prefix. The password will be stored using pass at <passprefix><email>
 .TP
-.B -c certificate
-Self-signed TLS certificate
+.B -c path
+Path to self-signed TLS certificate
 .SH OTHER OPTIONS
 .TP
 .B -f


### PR DESCRIPTION
I added an option `-c path` to `mw` to allow user to provide the path to a self-signed TLS certificate.

Once the user adds this option, the `mw` script will:
1. Overwrite `$sslcert` with the provided path.
2. Add the option `-k` to `curl` to skip verifying the certificate.

It would be useful for users to setup mutt to connect imap/smtp servers with self-signed certificate, like Proton Mail Bridge.