### PR TITLE
start the browser process ran by urlview in the background

### DIFF
--- a/bin/mw
+++ b/bin/mw
@@ -234,7 +234,7 @@ finalize() {
 	[ "$type" != "online" ] && echo "$mailboxes" | xargs -I {} mkdir -p "$maildir/$fulladdr/{}/cur" "$maildir/$fulladdr/{}/tmp" "$maildir/$fulladdr/{}/new"
 	mkdir -p "$cachedir/$safename/bodies"
 	echo "$fulladdr (account #$idnum) added successfully."
-	command -V urlview >/dev/null 2>&1 && [ ! -f "$HOME/.urlview" ] && echo "COMMAND \$BROWSER" >"$HOME/.urlview"
+	command -V urlview >/dev/null 2>&1 && [ ! -f "$HOME/.urlview" ] && echo "COMMAND setsid -f \$BROWSER >/dev/null 2>&1" >"$HOME/.urlview"
 	return 0
 }
 


### PR DESCRIPTION
When there is no browser window open, urlview runs the browser process in the current terminal, which results in two problems:
1. Hiding the mutt interface so you can't get back to your emails unless you close the browser window, which is really annoying.
2. Closing the browser window when closing the current terminal, which is especially annoying when you're done with your emails and you just want the current webpage to stay open.