### PR TITLE
Add gettext dependency to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Specifically, this wizard:
 - `msmtp` - sends the email.
 - `pass` - safely encrypts passwords (required at install).
 - `ca-certificates` - required for SSL. Probably installed already.
+- `gettext` - writes config files. Probably installed already.
 
 **Note**: There's a chance of errors if you use a slow-release distro like
 Ubuntu, Debian, or Mint. If you get errors in `neomutt`, install the most


### PR DESCRIPTION
gettext which provides the envsubst command is not installed on all distributions. Void for instance does not come with this, so I think it should be mentioned in the README.