### PR TITLE
update header cache database

### DIFF
--- a/share/mutt-wizard.muttrc
+++ b/share/mutt-wizard.muttrc
@@ -29,6 +29,8 @@ auto_view text/html		# automatically show html (mailcap uses lynx)
 auto_view application/pgp-encrypted
 #set display_filter = "tac | sed '/\\\[-- Autoview/,+1d' | tac" # Suppress autoview messages.
 alternative_order text/plain text/enriched text/html
+# change header cache database from older kyotocabinet for improved performance
+set header_cache_backend = "lmdb"
 
 bind index,pager i noop
 bind index,pager g noop


### PR DESCRIPTION
Thanks to the tip of [@flatcap](https://github.com/flatcap) in issue https://github.com/neomutt/neomutt/issues/3919 I've updated my muttrc to use `lmdb` instead of the kyotocabinet (default?) and there is a huge difference :exploding_head: 

Changing folders and mailboxes is now blazingly fast :zap: 