### PR TITLE
exclude dovecot special folders fts-flatcurve/virtual

### DIFF
--- a/share/mbsync-temp
+++ b/share/mbsync-temp
@@ -16,7 +16,7 @@ Channel $fulladdr
 Expunge Both
 $master :$fulladdr-remote:
 $slave :$fulladdr-local:
-Patterns * !"[Gmail]/All Mail"
+Patterns * !"[Gmail]/All Mail" !"*fts-flatcurve*" !"*virtual*"
 Create Both
 SyncState *
 MaxMessages $maxmes


### PR DESCRIPTION
These folders only contain files that are used internall by dovecot and cause errors when synced with mbsync. So we can exclude them by default.