### PR TITLE
if mbsync -v is less than 1.4.0 use old format, else use new format

### DIFF
--- a/bin/mw
+++ b/bin/mw
@@ -29,14 +29,14 @@ maxmes="0"
 
 alias mbsync='mbsync -c "$mbsyncrc"'
 
-# mbsync now requires "Far/Near" rather than "Master/Slave", but Ubuntu/Debian
-# have the older version.
-if command -V apt-get >/dev/null 2>&1; then
-	master="Master"
-	slave="Slave"
-else
-	master="Far"
-	slave="Near"
+# mbsync >= 1.4.0 requires "Far/Near" rather than "Master/Slave"
+master="Far"
+slave="Near"
+mbsync_version=$(mbsync --version | cut -d' ' -f2)
+#check if version is less than 1.4.0
+if [[ "$(printf '1.4.0\n%s' "$mbsync_version" | sort -V | head -n1)" != "1.4.0" ]]; then
+  master="Master"
+  slave="Slave"
 fi
 
 for x in "/etc/ssl/certs/ca-certificates.crt" \


### PR DESCRIPTION
Replace the check of apt-get with a check that looks at the version number of mbsync and use the old format if the version number is less than 1.4.0