### PR TITLE
Fix notify-send not coming through with goimapnotify

### DIFF
--- a/bin/mailsync
+++ b/bin/mailsync
@@ -63,11 +63,11 @@ syncandnotify() {
 	newcount=$(echo "$new" | sed '/^\s*$/d' | wc -l)
 	case 1 in
 		$((newcount > 5)) )
-			echo "$newcount new mail for $2."
+			echo "$newcount new mail for $2." >/dev/tty
 			[ -z "$MAILSYNC_MUTE" ] && notify "New Mail!" "📬 $newcount new mail(s) in \`$2\` account."
 			;;
 		$((newcount > 0)) )
-			echo "$newcount new mail for $2."
+			echo "$newcount new mail for $2." >/dev/tty
 			[ -z "$MAILSYNC_MUTE" ] &&
 			for file in $new; do
 		    		# Extract and decode subject and sender from mail.


### PR DESCRIPTION
When goimapnotify runs mailsync, like when running the setup in #924, the echo by itself somehow interferes with notify-send, causing the notifications for new emails to not come through. I'm not sure why. Redirecting the echo to `/dev/tty` solves it, and it keeps the normal echo functionality intact.