### PR TITLE
Add capability to obscure notifications for specific sender addresses

### DIFF
--- a/bin/mailsync
+++ b/bin/mailsync
@@ -30,6 +30,7 @@ export GPG_TTY="$(tty)"
 [ -n "$MPOPRC" ] || MPOPRC="$HOME/.config/mpop/config"
 
 lastrun="${XDG_CONFIG_HOME:-$HOME/.config}/mutt/.mailsynclastrun"
+hidelist="${XDG_CONFIG_HOME:-$HOME/.config}/mutt/hidelist"
 
 # Settings are different for MacOS (Darwin) systems.
 case "$(uname)" in
@@ -75,8 +76,21 @@ syncandnotify() {
 					perl -CS -MEncode -ne 'print decode("MIME-Header", $_)')"
 				from="$(sed -n "/^From:/ s|From: *|| p" "$file" |
 					perl -CS -MEncode -ne 'print decode("MIME-Header", $_)')"
-				from="${from% *}" ; from="${from%\"}" ; from="${from#\"}"
-				notify "📧$from:" "$subject"
+
+				fromaddr="${from#*<}" fromaddr="${fromaddr%*>}"
+
+				# Hide email notifications for sender address patterns in hidelist file
+				while IFS= read -r pattern; do
+					echo "$fromaddr" | grep -q "^$pattern$" && break
+				done  <<-EOT
+				$(sed 's/#.*//' "$hidelist")
+				EOT
+
+				[ "$?" = 0 ] && notify "New Mail!" "📬 1 new mail in \`$2\` account." ||
+					{ fromperson="${from% *}"
+					  fromperson="${fromperson%\"}"
+					  fromperson="${fromperson#\"}";
+					  notify "📧$fromperson:" "$subject"; }
 			done
 			;;
 		*) echo "No new mail for $2." ;;

--- a/bin/mw
+++ b/bin/mw
@@ -7,6 +7,7 @@ maildir="${XDG_DATA_HOME:-$HOME/.local/share}/mail"
 muttshare="$prefix/share/mutt-wizard"
 cachedir="${XDG_CACHE_HOME:-$HOME/.cache}/mutt-wizard"
 muttrc="${XDG_CONFIG_HOME:-$HOME/.config}/mutt/muttrc"
+hidelist="${XDG_CONFIG_HOME:-$HOME/.config}/mutt/hidelist"
 accdir="${XDG_CONFIG_HOME:-$HOME/.config}/mutt/accounts"
 msmtprc="${XDG_CONFIG_HOME:-$HOME/.config}/msmtp/config"
 msmtplog="${XDG_STATE_HOME:-$HOME/.local/state}/msmtp/msmtp.log"
@@ -87,6 +88,10 @@ prepmutt() {
 	echo "macro index,pager i$idnum '<sync-mailbox><enter-command>source $accdir/$fulladdr.muttrc<enter><change-folder>!<enter>;<check-stats>' \"switch to $fulladdr\"" >>"$muttrc"
 }
 
+prephidelist() {
+	[ ! -f "$hidelist" ] && echo "# For all sender email address patterns in this file, the sender and the message will not be shown in notifications.\n#\n# Example entries:\n#\n# test@example.com\n# .*@example.com\n# test@.*\.com" >"$hidelist"
+}
+
 getprofiles() {
 	safename="$(echo $fulladdr | sed 's/@/_/g')"
 	case "$type" in
@@ -106,6 +111,7 @@ getprofiles() {
 	prepmsmtp
 	prepmutt
 	prepnotmuch
+	prephidelist
 }
 
 parsedomains() {


### PR DESCRIPTION
I like my privacy, as people running LARBS often do. Whenever I'm somewhere in public where other people can see my screen, I'd like them to not see full email notifications from all senders, though I'm OK with them seeing notifications for nonconfidential emails.

This PR fixes this issue by adding a separate file where users can define regex patterns of sender email addresses, for which notifications will be obscured with a general 'New mail!' notification.