### PR TITLE
cleanup Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,39 +1,27 @@
 .POSIX:
 
-OS = $(shell uname -s)
-ifndef PREFIX
-  PREFIX = /usr/local
-endif
-ifndef MANPREFIX
-  MANPREFIX = $(PREFIX)/share/man
-endif
+PREFIX = /usr/local
+MANPREFIX = $(PREFIX)/share/man
 
 install:
 	mkdir -p $(DESTDIR)$(PREFIX)/bin
 	mkdir -p $(DESTDIR)$(PREFIX)/lib/mutt-wizard
-	cp -f bin/mw bin/mailsync $(DESTDIR)$(PREFIX)/bin/
-	cp -f lib/openfile $(DESTDIR)$(PREFIX)/lib/mutt-wizard
-	chmod 755 $(DESTDIR)$(PREFIX)/bin/mw $(DESTDIR)$(PREFIX)/bin/mailsync $(DESTDIR)$(PREFIX)/lib/mutt-wizard/openfile
 	mkdir -p $(DESTDIR)$(PREFIX)/share/mutt-wizard
+	cp -f bin/mailsync $(DESTDIR)$(PREFIX)/bin
+	cp -f lib/openfile $(DESTDIR)$(PREFIX)/lib/mutt-wizard
 	chmod 755 $(DESTDIR)$(PREFIX)/share/mutt-wizard
 	for shared in share/*; do \
 		cp -f $$shared $(DESTDIR)$(PREFIX)/share/mutt-wizard; \
 		chmod 644 $(DESTDIR)$(PREFIX)/share/mutt-wizard/$$(basename $(notdir $$shared)); \
 	done
 	mkdir -p $(DESTDIR)$(MANPREFIX)/man1
-	cp -f mw.1 $(DESTDIR)$(MANPREFIX)/man1/mw.1
 	cp -f mailsync.1 $(DESTDIR)$(MANPREFIX)/man1/mailsync.1
+	sed 's:/usr/local:$(PREFIX):' < share/mutt-wizard.muttrc > $(DESTDIR)$(PREFIX)/share/mutt-wizard/mutt-wizard.muttrc
+	sed 's:/usr/local:$(PREFIX):' < share/mailcap > $(DESTDIR)$(PREFIX)/share/mutt-wizard/mailcap
+	sed 's:/usr/local:$(PREFIX):' < bin/mw > $(DESTDIR)$(PREFIX)/bin/mw
+	sed 's:/usr/local:$(PREFIX):' < mw.1 > $(DESTDIR)$(MANPREFIX)/man1/mw.1
 	chmod 644 $(DESTDIR)$(MANPREFIX)/man1/mw.1 $(DESTDIR)$(MANPREFIX)/man1/mailsync.1
-	if [ "$(PREFIX)" ]; then \
-		sed -iba 's:/usr/local:$(PREFIX):' $(DESTDIR)$(PREFIX)/share/mutt-wizard/mutt-wizard.muttrc; \
-		rm -f $(DESTDIR)$(PREFIX)/share/mutt-wizard/mutt-wizard.muttrcba; \
-		sed -iba 's:/usr/local:$(PREFIX):' $(DESTDIR)$(PREFIX)/bin/mw; \
-		rm -f $(DESTDIR)$(PREFIX)/bin/mwba; \
-		sed -iba 's:/usr/local:$(PREFIX):' $(DESTDIR)$(MANPREFIX)/man1/mw.1; \
-		rm -f $(DESTDIR)$(MANPREFIX)/man1/mw.1ba; \
-		sed -iba 's:/usr/local:$(PREFIX):' $(DESTDIR)$(PREFIX)/share/mutt-wizard/mailcap; \
-		rm -f $(DESTDIR)$(PREFIX)/share/mutt-wizard/mailcapba; \
-	fi
+	chmod 755 $(DESTDIR)$(PREFIX)/bin/mw $(DESTDIR)$(PREFIX)/bin/mailsync $(DESTDIR)$(PREFIX)/lib/mutt-wizard/openfile
 	mkdir -p $(DESTDIR)$(PREFIX)/share/zsh/site-functions/
 	chmod 755 $(DESTDIR)$(PREFIX)/share/zsh/site-functions/
 	cp -f completion/_mutt-wizard.zsh $(DESTDIR)$(PREFIX)/share/zsh/site-functions/_mutt-wizard.zsh


### PR DESCRIPTION
* OS variable was unused
* ifndef section is not needed since "make PREFIX=... MANPREFIX=..." overwrites whatever is set there
* notdir is a GNU specific function (not POSIX) and doesn't do anything in this case
* "sed -i" is not POSIX and pointless if pipes are used correctly
* the "if" block can be removed since "sed" can also be used to copy files to the destination.