### PR TITLE
No mailsync with locked GPG key in non-interactive shells

### DIFF
--- a/bin/mailsync
+++ b/bin/mailsync
@@ -24,6 +24,9 @@ eval "$(grep -h -- \
 	"$HOME/.config/zsh/.zshenv" "$HOME/.bashrc" "$HOME/.zshrc" "$HOME/.config/zsh/.zshrc" \
 	"$HOME/.pam_environment" 2>/dev/null)"
 
+# For non-interactive shell (e.g. cron job) run only when the GPG key (in $GNUPGHOME or pass --homedir) is unlocked
+tty -s || (echo "dummy" | gpg --sign --batch --pinentry-mode error -o /dev/null > /dev/null 2>&1) || exit
+
 export GPG_TTY="$(tty)"
 
 [ -n "$MBSYNCRC" ] && alias mbsync="mbsync -c $MBSYNCRC" || MBSYNCRC="$HOME/.mbsyncrc"


### PR DESCRIPTION
Assume you
- use `pass` with a password-protected GPG key
- clear cached passwords when locking screen
- run a local mail server
- use cron to run `mailsync`
- don't want to clear `MAILTO` in case actual errors happen

If so, cron will spam the server with "no secret key" emails. This one-liner prevents it.