### PR TITLE
Don't prompt for password, if the email address already has one stored.

### DIFF
--- a/bin/mw
+++ b/bin/mw
@@ -173,11 +173,11 @@ askinfo() {
 	[ -z "$passprefix" ] && passprefix=""
 	hostname="${fulladdr#*@}"
 	login="${login:-$fulladdr}"
-	if [ -n "${password+x}" ]; then
+	if [ -n "${password+x}" ] && [ ! -f "$PASSWORD_STORE_DIR/$passprefix$fulladdr.gpg" ]; then
 		insertpass
-	else
+	elif [ ! -f "$PASSWORD_STORE_DIR/$passprefix$fulladdr.gpg" ]; then
 		getpass
-	fi
+    fi
 }
 
 insertpass() {


### PR DESCRIPTION
Check if a password is already stored for the email address. This could happen if you simply move your .password-store directory when reinstalling or migrating to another system. If one is stored, `mw` will not attempt to create one, under the assumption that the old password is still valid.