### PR TITLE
Added direct link to Google App Password page for easier access

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,8 @@ To give you an example of the interface, here's an idea:
   applications requires turning off two-factor authentication and this will
   circumvent that. You might also need to manually "Enable IMAP" in the
   settings.
+  To create an App Password for your Google account,
+  you can directly visit the [App Passwords](https://myaccount.google.com/apppasswords) page in your Google Account settings.
 - If you have a university email or enterprise-hosted email for work, there
   might be other hurdles or two-factor authentication you have to jump through.
   Some, for example, will want you to create a separate IMAP password, etc.


### PR DESCRIPTION
This commit addresses the issue where new users who haven't set an app password before can't find the option under 2-Step Verification in their Google Account settings, as explained in the provided link (https://support.google.com/accounts/answer/185833?hl=en). To improve user experience, a direct link to the App Password page in Google Account settings has been added.