### PR TITLE
fix(mailsync): delimit notification text from flags

### DIFF
--- a/bin/mailsync
+++ b/bin/mailsync
@@ -45,7 +45,7 @@ case "$(uname)" in
 
 	notify() { [ -n "$pgrepoutput" ] && for x in ${displays:-:0}; do
 			export DISPLAY="$x"
-			notify-send --app-name="mutt-wizard" "$1" "$2"
+			notify-send --app-name="mutt-wizard" -- "$1" "$2"
 		done ;}
 	;;
 esac


### PR DESCRIPTION
Fixes text being interpreted as flags when it starts with a dash. Try sending yourself a letter with subject starting with '-'. E.g. if subject is '-10%' fixes error:
> Unknown option -10%