### PR TITLE
Fix #922 (Notice: SSLType is deprecated. Use TLSType instead.)

### DIFF
--- a/share/mbsync-temp
+++ b/share/mbsync-temp
@@ -4,7 +4,7 @@ Port $iport
 User $login
 PassCmd "pass $passprefix$fulladdr"
 AuthMechs LOGIN
-SSLType $imapssl
+TLSType $imapssl
 CertificateFile $sslcert
 
 MaildirStore $fulladdr-local


### PR DESCRIPTION
Fixes the `Notice: SSLType is deprecated. Use TLSType instead.` warning. Let me know if any other file needs changing.