### PR TITLE
Fix unary operator expected error

### DIFF
--- a/bin/mw
+++ b/bin/mw
@@ -34,7 +34,11 @@ alias mbsync='mbsync -c "$mbsyncrc"'
 # mbsync >=1.4.0 requires "Far/Near" rather than "Master/Slave."
 mbver="$(mbsync -v)"
 mbver="${mbver#* }"
-if [ "${mbver%.*}" >= 1.4 ]; then
+mbver="${mbver%.*}"
+# Comparing two float numbers in bash is a pain in the butt, so we get rid of
+# dots and turn them into nice integers
+mbver="${mbver/\./}"
+if [ "${mbver}" -gt 14 ]; then
 	master="Far"
 	slave="Near"
 else


### PR DESCRIPTION
On my system running any `mw` command after a fresh install from the AUR, I get:

```
/usr/bin/mw: line 37: [: 1.5: unary operator expected
```

Now the script doesn't error per-se but it does set the `master` and `slave` variables to wrong values. I'm also not sure how this wasn't raised before; maybe that's a new bash version thing? I'm on 5.2.37.

Anyway I faffed around trying to fix this, in particular with the `-gt` operator but it turned out that properly comparing float numbers is a pain in the butt in bash. I found solutions using `bc` which I thought were weird.

To keep things simple I ended up doing a little substitution on the dot `.` character and turned these nasty floats into integers, along with using the `-gt` operator which did the trick on my system. May be unorthodox so feedback is more than welcome.

Thank you for the great software by the way, lots of gratitude for your work.