### PR TITLE
Allow PREFIX to be set by user

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .POSIX:
 
-PREFIX = /usr/local
+PREFIX ?= /usr/local
 MANPREFIX = $(PREFIX)/share/man
 
 install:


### PR DESCRIPTION
This allows for the following command to work:

```
PREFIX=$HOME/.local make install
```

The makefile already handles the `PREFIX` not being at `/usr/local`