### PR TITLE
Rename muttrc variable

### DIFF
--- a/share/mutt-temp
+++ b/share/mutt-temp
@@ -6,7 +6,7 @@ set sendmail = "msmtp -a $fulladdr"
 alias me $realname <$fulladdr>
 set folder = "$folder"
 set header_cache = "$cachedir/$safename/headers"
-set message_cachedir = "$cachedir/$safename/bodies"
+set message_cache_dir = "$cachedir/$safename/bodies"
 set mbox_type = Maildir
 set hostname = "$hostname"
 source $muttshare/switch.muttrc


### PR DESCRIPTION
$message_cachedir has been renamed to $message_cache_dir:
https://neomutt.org/guide/reference.html#3-244-%C2%A0message_cache_dir