### PR TITLE
feat(completion): add Fish shell completions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,11 +26,16 @@ install:
 	chmod 755 $(DESTDIR)$(PREFIX)/share/zsh/site-functions/
 	cp -f completion/_mutt-wizard.zsh $(DESTDIR)$(PREFIX)/share/zsh/site-functions/_mutt-wizard.zsh
 	chmod 644 $(DESTDIR)$(PREFIX)/share/zsh/site-functions/_mutt-wizard.zsh
+	mkdir -p $(DESTDIR)$(PREFIX)/share/fish/vendor_completions.d/
+	chmod 755 $(DESTDIR)$(PREFIX)/share/fish/vendor_completions.d/
+	cp -f completion/mw.fish $(DESTDIR)$(PREFIX)/share/fish/vendor_completions.d/mw.fish
+	chmod 644 $(DESTDIR)$(PREFIX)/share/fish/vendor_completions.d/mw.fish
 
 uninstall:
 	rm -f $(DESTDIR)$(PREFIX)/bin/mw $(DESTDIR)$(PREFIX)/bin/mailsync $(DESTDIR)$(PREFIX)/lib/mutt-wizard/openfile
 	rm -rf $(DESTDIR)$(PREFIX)/share/mutt-wizard  $(DESTDIR)$(PREFIX)/lib/mutt-wizard
 	rm -f $(DESTDIR)$(MANPREFIX)/man1/mw.1  $(DESTDIR)$(MANPREFIX)/man1/mailsync.1
 	rm -f $(DESTDIR)$(PREFIX)/share/zsh/site-functions/_mutt-wizard.zsh
+	rm -f $(DESTDIR)$(PREFIX)/share/fish/vendor_completions.d/mw.fish
 
 .PHONY: install uninstall

--- a/completion/mw.fish
+++ b/completion/mw.fish
@@ -1,0 +1,30 @@
+# Fish shell completions for mw (mutt-wizard) command
+
+# Main flags (first argument)
+complete -c mw -n "not __fish_seen_subcommand_from -a -l -d -D -y -Y -t -T -r" -s a -d "Add an email address"
+complete -c mw -n "not __fish_seen_subcommand_from -a -l -d -D -y -Y -t -T -r" -s l -d "List email addresses configured"
+complete -c mw -n "not __fish_seen_subcommand_from -a -l -d -D -y -Y -t -T -r" -s d -d "Remove an already added address"
+complete -c mw -n "not __fish_seen_subcommand_from -a -l -d -D -y -Y -t -T -r" -s D -d "Force remove account without confirmation"
+complete -c mw -n "not __fish_seen_subcommand_from -a -l -d -D -y -Y -t -T -r" -s y -d "Sync mail for account by name"
+complete -c mw -n "not __fish_seen_subcommand_from -a -l -d -D -y -Y -t -T -r" -s Y -d "Sync mail for all accounts"
+complete -c mw -n "not __fish_seen_subcommand_from -a -l -d -D -y -Y -t -T -r" -s t -d "Toggle automatic mailsync every <number> minutes"
+complete -c mw -n "not __fish_seen_subcommand_from -a -l -d -D -y -Y -t -T -r" -s T -d "Toggle automatic mailsync every 10 minutes"
+complete -c mw -n "not __fish_seen_subcommand_from -a -l -d -D -y -Y -t -T -r" -s r -d "Order account numbers"
+
+# Sub-options for -a (add email address)
+complete -c mw -n "__fish_seen_subcommand_from -a" -s u -d "Account login name if not full address"
+complete -c mw -n "__fish_seen_subcommand_from -a" -s n -d "Real name to be on the email account"
+complete -c mw -n "__fish_seen_subcommand_from -a" -s i -d "IMAP/POP server address"
+complete -c mw -n "__fish_seen_subcommand_from -a" -s I -d "IMAP/POP server port"
+complete -c mw -n "__fish_seen_subcommand_from -a" -s s -d "SMTP server address"
+complete -c mw -n "__fish_seen_subcommand_from -a" -s S -d "SMTP server port"
+complete -c mw -n "__fish_seen_subcommand_from -a" -s x -d "Password for account (recommended to be in double quotes)"
+complete -c mw -n "__fish_seen_subcommand_from -a" -s P -d "Pass Prefix (prefix of the file where password is stored)"
+complete -c mw -n "__fish_seen_subcommand_from -a" -s p -d "Add for a POP server instead of IMAP"
+complete -c mw -n "__fish_seen_subcommand_from -a" -s X -d "Delete an account's local email too when deleting"
+complete -c mw -n "__fish_seen_subcommand_from -a" -s o -d "Configure address, but keep mail online"
+complete -c mw -n "__fish_seen_subcommand_from -a" -s f -d "Assume typical English mailboxes without attempting log-on"
+
+# Email address completions for -D and -y flags
+complete -c mw -n "__fish_seen_subcommand_from -D" -f -a "(mw -l 2>/dev/null | cut -f2)"
+complete -c mw -n "__fish_seen_subcommand_from -y" -f -a "(mw -l 2>/dev/null | cut -f2)"


### PR DESCRIPTION
# Add Fish Shell Completions for Mutt-Wizard

![Screenshot 2025-06-16 at 4 08 34 PM](https://github.com/user-attachments/assets/16f39ca5-f085-46d0-8849-5bb06c869289)

## Summary

This PR adds Fish shell completion support for the `mw` (mutt-wizard) command. The implementation includes comprehensive tab-completion options for all available command flags and subcommands, enhancing the user experience for Fish shell users.

## Files Changed

### 1. Makefile

Modified the installation and uninstallation process to include Fish shell completions:

- Added commands to create the Fish vendor completions directory
- Added commands to copy and set permissions for the Fish completion file
- Added removal of the Fish completion file during uninstallation

### 2. completion/mw.fish (New File)

Created a new Fish shell completion file that provides:

- Completions for all main command flags (`-a`, `-l`, `-d`, etc.)
- Contextual sub-options for the `-a` (add email address) command
- Dynamic completion of email addresses for the `-D` and `-y` flags by parsing  the output of `mw -l`

## Reason for Changes

Fish shell is a popular alternative to Bash and Zsh that offers advanced features like autosuggestions and robust tab completion. This change improves the user experience for Fish shell users by providing the same level of command completion that was previously only available for Zsh users.

## Impact of Changes

- Fish shell users will now have access to comprehensive tab completion for the `mw` command
- The installation and uninstallation processes have been updated to handle the new Fish completion file
- No impact on existing functionality for non-Fish users

## Test Plan

- Installed the completions using `make install`
- Verified that Fish shell correctly loads the completions
- Tested tab completion for various commands and subcommands
- Verified that dynamic email address completion works correctly
- Confirmed that `make uninstall` properly removes the Fish completion file

## Additional Notes

The Fish completion file follows the same pattern as the existing Zsh completion, but uses Fish's specific completion syntax. The implementation is comprehensive and covers all command options available in the `mw` tool.
