### PR TITLE
Fix .conf to .yaml in goimapnotify config file

### DIFF
--- a/bin/mw
+++ b/bin/mw
@@ -86,7 +86,7 @@ prepmpop() {
 }
 
 prepimapnotify() {
-  mkdir -p "$imapnotify" ; envsubst < "$imapnotifytemp" >> "$imapnotify/$fulladdr.conf"
+  mkdir -p "$imapnotify" ; envsubst < "$imapnotifytemp" >> "$imapnotify/$fulladdr.yaml"
 }
 
 prepmutt() {


### PR DESCRIPTION
9 months ago the systemd unit for goimapnotify changed from using `.conf` to `.yaml` not making the change will cause your email setup to stop sending push notifications

https://gitlab.com/shackra/goimapnotify/-/blame/master/goimapnotify@.service?ref_type=heads#L8

![image](https://github.com/user-attachments/assets/6f97c813-1264-443c-b94b-180a42dc9c36)
