### PR TITLE
fix: `head` incompatibility between GNU and macOS

### DIFF
--- a/bin/mailsync
+++ b/bin/mailsync
@@ -74,7 +74,7 @@ syncandnotify() {
 			[ -z "$MAILSYNC_MUTE" ] &&
 			for file in $new; do
 				# Extract and decode subject and sender from mail.
-				subject=$(awk '/^Subject: / && ++n == 1,/^.*: / && ++i == 2' "$file" | head -n-1 |
+				subject=$(awk '/^Subject: / && ++n == 1,/^.*: / && ++i == 2' "$file" | sed '$d' |
 					perl -CS -MEncode -ne 'print decode("MIME-Header", $_)' |
 					sed 's/^Subject: //' | tr -d '\n\t')
 				from="$(sed -n "/^From:/ s|From: *|| p" "$file" |


### PR DESCRIPTION
The `head` command give the following error on macOS when called with -1: `head: illegal line count -- -1`. `sed '$d'` works for me with the GNU version of sed as well as the one on macOS and should accomplish the same goal of removing the last line.