### PR TITLE
Handle sync errors (set exit code accordingly)

### DIFF
--- a/bin/mailsync
+++ b/bin/mailsync
@@ -58,7 +58,7 @@ syncandnotify() {
 	case "$1" in
 		imap) mbsync -q "$2" ;;
 		pop) mpop -q "$2" ;;
-	esac
+	esac || return 1
 	new=$(find\
 		"$HOME/.local/share/mail/$2/"[Ii][Nn][Bb][Oo][Xx]/new/ \
 		"$HOME/.local/share/mail/$2/"[Ii][Nn][Bb][Oo][Xx]/cur/ \
@@ -100,15 +100,34 @@ else
 	done || echo "error $arg"; done)"
 fi
 
+pids=      # PIDs of backgrounded subshells
+count=0    # number of accounts in $tosync
+failed=0   # number of failed sync attempts
 for account in $tosync; do
+	count=$((count+1))
 	case $account in
-		Channel*) syncandnotify imap "${account##* }" & ;;
-		account*) syncandnotify pop "${account##* }" & ;;
-		error*) echo "ERROR: Account ${account##* } not found." ;;
+		Channel*)
+			syncandnotify imap "${account##* }" &
+			pids="$pids $!"
+			;;
+		account*)
+			syncandnotify pop "${account##* }" &
+			pids="$pids $!"
+			;;
+		error*)
+			echo "ERROR: Account ${account##* } not found."
+			failed=$((failed+1))
+			;;
 	esac
 done
 
-wait
+IFS=' '
+for pid in $pids; do
+	wait $pid || failed=$((failed+1))
+done
+
+# Abort if no account sync succeeded
+[ "$count" -gt "$failed" ] || exit 1
 
 notmuch new --quiet
 


### PR DESCRIPTION
Hi,
Currently mailsync exits with code 0 (success) even when mbsync/mpop fails to sync.
This PR makes it so it exits with failure (exit code 1) when all account sync attempts fail.
It also makes the syncandnotify() function return early when the sync fails instead of running through the rest of the function for no reason.

Use case:
When I run mailsync through torsocks, mbsync initially fails sometimes until it eventually works (not a mutt-wizard issue). So I thought I'd loop it until it succeeds. Problem: there was no direct way of knowing whether it failed or not.
Sure, this is a hack for a very specific use case, but I'm sure there are many more situations in which people expect a failure exit code upon failure.

I had to complicate the code a bit to consistently support multi account syncs, and it seemed reasonable to make it fail only if none succeeded.