### PR TITLE
Replace head -n-1 with POSIX-compatible sed '$d'

### DIFF
--- a/bin/mailsync
+++ b/bin/mailsync
@@ -74,7 +74,7 @@ syncandnotify() {
 			[ -z "$MAILSYNC_MUTE" ] &&
 			for file in $new; do
 				# Extract and decode subject and sender from mail.
-				subject=$(awk '/^Subject: / && ++n == 1,/^.*: / && ++i == 2' "$file" | head -n-1 |
+				subject=$(awk '/^Subject: / && ++n == 1,/^.*: / && ++i == 2' "$file" | sed '$d' |
 					perl -CS -MEncode -ne 'print decode("MIME-Header", $_)' |
 					sed 's/^Subject: //' | tr -d '\n\t')
 				from="$(sed -n "/^From:/ s|From: *|| p" "$file" |


### PR DESCRIPTION
The GNU-specific head -n-1 syntax causes errors on macOS/BSD systems. Replaced with sed '$d' which is POSIX-compatible and achieves the same result of removing the last line.