### PR TITLE
Update mbsync-temp

### DIFF
--- a/share/mbsync-temp
+++ b/share/mbsync-temp
@@ -4,7 +4,7 @@ Port $iport
 User $login
 PassCmd "pass $passprefix$fulladdr"
 AuthMechs LOGIN
-SSLType $imapssl
+TLSType $imapssl
 CertificateFile $sslcert
 
 MaildirStore $fulladdr-local


### PR DESCRIPTION
I updated the file mbsync-temp from SSLType to TLSType because I got a deprecated error message for SSL.