### PR TITLE
Added --proxy to curl

### DIFF
--- a/bin/mw
+++ b/bin/mw
@@ -221,7 +221,7 @@ getboxes() {
 	if [ -n "${force+x}" ]; then
 		mailboxes="$(printf "INBOX\\nDrafts\\nJunk\\nTrash\\nSent\\nArchive")"
 	else
-		info="$(curl --location-trusted -s -m 5 --user "$login:$(pass "$passprefix$fulladdr")" --url "${protocol:-imaps}://$imap:${iport:-993}")"
+		info="$(curl --proxy "$proxy" --location-trusted -s -m 5 --user "$login:$(pass "$passprefix$fulladdr")" --url "${protocol:-imaps}://$imap:${iport:-993}")"
 		[ -z "$info" ] && errorexit
 		mailboxes="$(echo "$info" | grep -v HasChildren | sed "s/.*\" //;s/\"//g" | tr -d '\r')"
 	fi
@@ -301,6 +301,7 @@ Options allowed with -a:
   -X	Delete an account's local email too when deleting.
   -o	Configure address, but keep mail online.
   -f	Assume typical English mailboxes without attempting log-on.
+  -R	Use a proxy server for curl (useful for bypassing network restrictions)
 
 NOTE: Once at least one account is added, you can run
 \`mbsync -a\` to begin downloading mail.
@@ -333,9 +334,10 @@ reorder() {
 	' "$tempfile" >>"$muttrc"
 }
 
-while getopts "rfpXlhodTYD:y:i:I:s:S:u:a:n:P:x:m:t:" o; do case "${o}" in
+while getopts "rfpXlhodTYD:y:i:I:s:S:u:a:n:P:x:m:t:R:" o; do case "${o}" in
 	l) setact list ;;
 	r) setact reorder ;;
+	R) proxy="$OPTARG" ;;
 	d) setact delete ;;
 	D)
 		setact delete

--- a/mw.1
+++ b/mw.1
@@ -73,6 +73,9 @@ Account password. You will be prompted for the password interactively if this op
 .TP
 .B -P
 Pass Prefix. The password will be stored using pass at <passprefix><email>
+.TP
+.B -R
+Use a proxy server for curl (useful for bypassing network restrictions)
 .SH OTHER OPTIONS
 .TP
 .B -f


### PR DESCRIPTION
Some regions have restricted access to internet. 
A proxy server is necessary for adding an email account if the user is using a specific mailing service that is restricted in their region.