### PR TITLE
Don't create ~/.msmtprc

### DIFF
--- a/bin/mw
+++ b/bin/mw
@@ -70,7 +70,6 @@ list() { getaccounts && [ -n "$accounts" ] && echo "$accounts" || exit 1; }
 
 prepmsmtp() {
 	mkdir -p "${msmtprc%/*}" "${msmtplog%/*}"
-	ln -s "$msmtprc" "$HOME/.msmtprc" 2>/dev/null
 	envsubst <"$msmtptemp" >>"$msmtprc"
 }
 


### PR DESCRIPTION
msmtp has XDG support (https://github.com/marlam/msmtp/commit/af2f409). Is there another reason for creating this file?